### PR TITLE
fix(skills): address Copilot review feedback on worktree safety

### DIFF
--- a/skills/cleanup/SKILL.md
+++ b/skills/cleanup/SKILL.md
@@ -110,11 +110,11 @@ before continuing. Do not silently skip warnings.
    (merged or gone-upstream) and you need to switch away from it:
 
    **Worktree context (primary path):** If `$PWD` contains `.claude/worktrees/<name>/`, return to
-   the worktree's designated branch (`claude/<name>`) instead of the default branch. Never run
-   `git switch main` in a worktree — it will fail if `main` is checked out elsewhere:
+   the worktree's designated branch (`claude/<name>`) instead of the default branch. Never switch
+   to the default branch in a worktree — it will fail if that branch is checked out elsewhere:
 
    ```sh
-   worktree_name=$(echo "$PWD" | sed -n 's|.*/.claude/worktrees/\([^/]*\)/.*|\1|p')
+   worktree_name=$(echo "$PWD" | sed -n 's|.*/.claude/worktrees/\([^/]*\)\(/.*\)\{0,1\}$|\1|p')
    if [ -n "$worktree_name" ]; then
      git switch "claude/${worktree_name}"
    else

--- a/skills/preflight/SKILL.md
+++ b/skills/preflight/SKILL.md
@@ -111,19 +111,20 @@ If `$PWD` contains `.claude/worktrees/<name>/`, check whether another session is
 this worktree:
 
 ```sh
-worktree_name=$(echo "$PWD" | sed -n 's|.*/.claude/worktrees/\([^/]*\)/.*|\1|p')
+worktree_name=$(echo "$PWD" | sed -n 's|.*/.claude/worktrees/\([^/]*\)\(/.*\)\{0,1\}$|\1|p')
 if [ -n "$worktree_name" ]; then
   project_dir=$(find ~/.claude/projects/ -maxdepth 1 -type d -name "*worktrees-${worktree_name}" | head -1)
   if [ -n "$project_dir" ]; then
-    active=$(find "$project_dir" -name '*.jsonl' -mmin -5 2>/dev/null | head -1)
+    active_count=$(find "$project_dir" -name '*.jsonl' -mmin -5 2>/dev/null | wc -l | tr -d ' ')
   fi
 fi
 ```
 
-If `active` is non-empty:
+If `active_count` is 2 or more (the current session has its own transcript, so 2+ means another
+session is also active):
 
-- **FAIL** — "Worktree `<name>` has an active session (transcript modified within 5 minutes).
-  Another agent is likely working here — dispatch to a different worktree."
+- **FAIL** — "Worktree `<name>` has an active session (multiple transcripts modified within 5
+  minutes). Another agent is likely working here — dispatch to a different worktree."
 
 If not in a worktree context, skip this check.
 


### PR DESCRIPTION
## Summary

Follow-up to #6 — addresses all 9 Copilot review comments:

- **Sed regex**: Fix worktree name extraction to handle `$PWD` at the worktree root (no trailing path). Uses `\(/.*\)\{0,1\}$` pattern across all three skills.
- **Self-detection false positive**: Change from "any recent transcript = conflict" to "2+ recent transcripts = conflict". The current session always has its own transcript, so only 2+ indicates another active session.
- **Variable naming**: Rename `designated_branch` to `current_branch` in pick-up-issue step 0 and add explicit comparison against expected `claude/<name>`.
- **Default branch language**: Soften "never `git switch main`" to "never switch to the default branch" to support repos using `master` or other defaults.
- **Cleanup language**: Soften pick-up-issue step 12 from "will return to" to "will attempt to return to" since cleanup has a fallback path.

## Test plan

- [ ] Verify sed regex matches both `.claude/worktrees/agent-alpha/` (with trailing path) and `.claude/worktrees/agent-alpha` (root)
- [ ] Verify 2+ transcript heuristic is consistent between pick-up-issue step 0 and preflight check 6
- [ ] Verify "default branch" language is consistent across all three files

🤖 Generated with [Claude Code](https://claude.com/claude-code)