### PR TITLE
fix: add PowerShell setup scripts for native Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ gets lost between runs.
 cd ~/code/bkonkle/skills && git pull
 ```
 
-Since skills are symlinked, existing ones update automatically. Run `./setup.sh` again only to
-pick up newly added skills or hooks.
+Since skills are symlinked, existing ones update automatically. Run `./setup.sh` (or `.\setup.ps1`
+on Windows) again only to pick up newly added skills or hooks.
 
 ## Writing New Skills
 
@@ -125,7 +125,8 @@ who's never seen the codebase — enough context to be autonomous, not so
 much that it's a novel.
 ```
 
-After adding a new skill, run `./setup.sh` to symlink it into `~/.claude/skills/`.
+After adding a new skill, run `./setup.sh` (or `.\setup.ps1` on Windows) to symlink it into
+`~/.claude/skills/`.
 
 Good skills are **specific**, **sequential**, and **verifiable** — they tell the agent what to do,
 in what order, and how to know it worked.

--- a/setup.ps1
+++ b/setup.ps1
@@ -42,13 +42,20 @@ function Install-Symlink {
         }
     }
 
-    New-Item -ItemType SymbolicLink -Path $Destination -Target $Source | Out-Null
+    try {
+        New-Item -ItemType SymbolicLink -Path $Destination -Target $Source | Out-Null
+    } catch [System.UnauthorizedAccessException] {
+        Write-Host ''
+        Write-Host 'Error: Symlink creation failed — insufficient privileges.' -ForegroundColor Red
+        Write-Host 'Enable Developer Mode (Settings > For developers) or run as Administrator.'
+        exit 1
+    }
     Write-Host "  $Label -> $Source"
 }
 
 # ── Statusline ────────────────────────────────────────────────────────────
 
-$statuslineSrc = Join-Path $ScriptDir 'statusline\statusline.sh'
+$statuslineSrc = Join-Path (Join-Path $ScriptDir 'statusline') 'statusline.sh'
 $statuslineDst = Join-Path $ClaudeDir 'statusline.sh'
 
 if (Test-Path $statuslineSrc) {
@@ -60,7 +67,7 @@ if (Test-Path $statuslineSrc) {
 $skillsDir = Join-Path $ScriptDir 'skills'
 Get-ChildItem -Directory $skillsDir | ForEach-Object {
     $src = $_.FullName
-    $dst = Join-Path $ClaudeDir "skills\$($_.Name)"
+    $dst = Join-Path (Join-Path $ClaudeDir 'skills') $_.Name
     Install-Symlink -Source $src -Destination $dst -Label "skill/$($_.Name)"
 }
 
@@ -70,7 +77,7 @@ $hooksDir = Join-Path $ScriptDir 'hooks'
 if (Test-Path $hooksDir) {
     Get-ChildItem -File $hooksDir | ForEach-Object {
         $src = $_.FullName
-        $dst = Join-Path $ClaudeDir "hooks\$($_.Name)"
+        $dst = Join-Path (Join-Path $ClaudeDir 'hooks') $_.Name
         Install-Symlink -Source $src -Destination $dst -Label "hook/$($_.Name)"
     }
 }


### PR DESCRIPTION
## Summary

- Adds `setup.ps1` (PowerShell equivalent of `setup.sh`) that symlinks skills, statusline, and hooks into `~/.claude/`
- Adds `install-skill.ps1` (PowerShell equivalent of `install-skill.sh`) for single skill installation
- Updates README with Windows (PowerShell) quick start section alongside existing Linux/macOS instructions

## Issue

Closes #8

## Test plan

- [ ] Run `.\setup.ps1` from an elevated PowerShell prompt or with Developer Mode enabled
- [ ] Verify skills are symlinked into `~/.claude/skills/`
- [ ] Run `.\install-skill.ps1` with no args — confirm usage output with skill list
- [ ] Run `.\install-skill.ps1 nonexistent` — confirm error message
- [ ] Run `.\install-skill.ps1 cleanup` — confirm single skill installed
- [ ] Verify `setup.sh` still works on Linux/macOS (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)