### PR TITLE
feat: make skills compatible with Claude and Codex

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,17 +13,17 @@
 
 # Skills
 
-> Reusable [Claude Code](https://docs.anthropic.com/en/docs/claude-code) skills for autonomous
+> Reusable [Claude Code](https://docs.anthropic.com/en/docs/claude-code) and Codex skills for autonomous
 > development workflows — issue triage, PR shepherding, session memory, and more.
 >
 > _From Colorado, with love._
 
-Skills are slash commands that teach Claude Code _how_ to do complex, multi-step tasks. They're
+Skills are command skills that teach Claude Code and Codex _how_ to do complex, multi-step tasks. They're
 plain Markdown files with structured instructions — readable by humans, executable by bots. Think of
 them as detailed route guides: clear enough for anyone to follow, thorough enough to get the job
 done without hand-holding.
 
-This repo is designed for a **worktree-based workflow**: multiple Claude Code sessions running in
+This repo is designed for a **worktree-based workflow**: multiple agent sessions running in
 parallel via `git worktree`, each on its own branch and its own path forward.
 
 ## Quick Start
@@ -74,7 +74,8 @@ To install a single skill:
 
 ---
 
-Skills are symlinked into `~/.claude/skills/`, so changes to this repo are reflected immediately —
+Skills are symlinked into `~/.claude/skills/` and `~/.codex/skills/`, so changes to this repo are
+reflected immediately —
 pull the repo and you're up to date. No reinstall needed.
 
 ## Skills
@@ -108,7 +109,7 @@ gets lost between runs.
 ## Extras
 
 - **`statusline/statusline.sh`** — CLI statusline showing session name, context %, cost, and model.
-  Detects worktree names from `.claude/worktrees/<name>/` paths.
+  Detects worktree names from `.claude/worktrees/<name>/` and `.codex/worktrees/<name>/` paths.
 - **`hooks/`** — Hook scripts (empty for now — add hooks as needed).
 
 ## Updating
@@ -139,7 +140,7 @@ much that it's a novel.
 ```
 
 After adding a new skill, run `./setup.sh` (or `.\setup.ps1` on Windows) to symlink it into
-`~/.claude/skills/`.
+`~/.claude/skills/` and `~/.codex/skills/`.
 
 Good skills are **specific**, **sequential**, and **verifiable** — they tell the agent what to do,
 in what order, and how to know it worked.
@@ -153,7 +154,7 @@ Recurring friction patterns from real-world multi-agent usage:
 | Wrong repo targeted | Agent derived repo from wrong remote | Use explicit `owner/repo` argument |
 | Push to wrong branch | Didn't verify tracking before push | Run `git branch -vv` before pushing |
 | CI won't trigger | Stale workflow YAML on branch | Rebase onto latest main |
-| Worktree branch conflict | Tried to switch to `main` | Use `claude/<worktree-name>` instead |
+| Worktree branch conflict | Tried to switch to `main` | Use `claude/<worktree-name>` or `codex/<worktree-name>` instead |
 | Cache misses after runner change | Mixed cache actions | Use repo's standard cache action consistently |
 | Repeated work | Didn't check prior sessions | Read `docs/agent-sessions/` and use `/recall` |
 | Stranded session memories | Memory committed to worktree branch, not in PR | Finalize memory before shepherding; `/cleanup` checks for orphans |
@@ -168,7 +169,7 @@ Skills are generic — they work across repos. For repo-specific behavior, add c
 - **Branch conventions** — naming patterns, protected branches
 - **Verification commands** — test/lint/build commands for the project's toolchain
 
-Skills like `/preflight` read `CLAUDE.md` to validate architecture constraints, so keeping it
+Skills like `/preflight` read `AGENTS.md`/`CLAUDE.md` to validate architecture constraints, so keeping those files
 accurate directly reduces agent mistakes.
 
 ## License

--- a/install-skill.sh
+++ b/install-skill.sh
@@ -2,10 +2,10 @@
 set -euo pipefail
 
 # ── Single skill installer ──────────────────────────────────────────────
-# Symlinks one skill from this repo into ~/.claude/skills/.
+# Symlinks one skill from this repo into ~/.claude/skills/ and ~/.codex/skills/.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-CLAUDE_DIR="$HOME/.claude"
+TARGET_ROOTS=("$HOME/.claude" "$HOME/.codex")
 SKILLS_DIR="$SCRIPT_DIR/skills"
 
 usage() {
@@ -33,17 +33,19 @@ if [ ! -d "$src" ]; then
   usage
 fi
 
-mkdir -p "$CLAUDE_DIR/skills"
-dst="$CLAUDE_DIR/skills/$skill_name"
+for target_root in "${TARGET_ROOTS[@]}"; do
+  mkdir -p "$target_root/skills"
+  dst="$target_root/skills/$skill_name"
 
-if [ -L "$dst" ]; then
-  ln -sf "$src" "$dst"
-elif [ -d "$dst" ]; then
-  echo "Backing up existing $dst → ${dst}.bak"
-  mv "$dst" "${dst}.bak"
-  ln -s "$src" "$dst"
-else
-  ln -s "$src" "$dst"
-fi
+  if [ -L "$dst" ]; then
+    ln -sf "$src" "$dst"
+  elif [ -d "$dst" ]; then
+    echo "Backing up existing $dst -> ${dst}.bak"
+    mv "$dst" "${dst}.bak"
+    ln -s "$src" "$dst"
+  else
+    ln -s "$src" "$dst"
+  fi
 
-echo "✓ skill/$skill_name → $src"
+  echo "✓ ${target_root##*/}/skill/$skill_name -> $src"
+done

--- a/setup.sh
+++ b/setup.sh
@@ -2,76 +2,56 @@
 set -euo pipefail
 
 # ── Skills repo installer ──────────────────────────────────────────────
-# Symlinks skills, statusline, and hooks from this repo into ~/.claude/.
+# Symlinks skills, statusline, and hooks from this repo into ~/.claude/
+# and ~/.codex/.
 # Idempotent — safe to run repeatedly.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-CLAUDE_DIR="$HOME/.claude"
+TARGET_ROOTS=("$HOME/.claude" "$HOME/.codex")
 
-# Ensure ~/.claude/ directories exist
-mkdir -p "$CLAUDE_DIR/skills" "$CLAUDE_DIR/hooks"
-
-# ── Statusline ──────────────────────────────────────────────────────────
-
-src="$SCRIPT_DIR/statusline/statusline.sh"
-dst="$CLAUDE_DIR/statusline.sh"
-
-if [ -L "$dst" ]; then
-  # Already a symlink — update it
-  ln -sf "$src" "$dst"
-elif [ -f "$dst" ]; then
-  echo "Backing up existing $dst → ${dst}.bak"
-  mv "$dst" "${dst}.bak"
-  ln -s "$src" "$dst"
-else
-  ln -s "$src" "$dst"
-fi
-echo "✓ statusline → $src"
-
-# ── Skills ──────────────────────────────────────────────────────────────
-
-for skill_dir in "$SCRIPT_DIR/skills"/*/; do
-  skill_name="$(basename "$skill_dir")"
-  src="$skill_dir"
-  dst="$CLAUDE_DIR/skills/$skill_name"
+install_link() {
+  local src="$1"
+  local dst="$2"
 
   if [ -L "$dst" ]; then
     ln -sf "$src" "$dst"
-  elif [ -d "$dst" ]; then
-    echo "Backing up existing $dst → ${dst}.bak"
+  elif [ -e "$dst" ]; then
+    echo "Backing up existing $dst -> ${dst}.bak"
     mv "$dst" "${dst}.bak"
     ln -s "$src" "$dst"
   else
     ln -s "$src" "$dst"
   fi
-  echo "✓ skill/$skill_name → $src"
-done
+}
 
-# ── Hooks ───────────────────────────────────────────────────────────────
+for target_root in "${TARGET_ROOTS[@]}"; do
+  mkdir -p "$target_root/skills" "$target_root/hooks"
 
-for hook_file in "$SCRIPT_DIR/hooks"/*; do
-  [ -f "$hook_file" ] || continue
-  hook_name="$(basename "$hook_file")"
-  src="$hook_file"
-  dst="$CLAUDE_DIR/hooks/$hook_name"
-
-  if [ -L "$dst" ]; then
-    ln -sf "$src" "$dst"
-  elif [ -f "$dst" ]; then
-    echo "Backing up existing $dst → ${dst}.bak"
-    mv "$dst" "${dst}.bak"
-    ln -s "$src" "$dst"
-  else
-    ln -s "$src" "$dst"
+  statusline_src="$SCRIPT_DIR/statusline/statusline.sh"
+  statusline_dst="$target_root/statusline.sh"
+  if [ -f "$statusline_src" ]; then
+    install_link "$statusline_src" "$statusline_dst"
+    echo "✓ ${target_root##*/}/statusline -> $statusline_src"
   fi
-  echo "✓ hook/$hook_name → $src"
-done
 
-# ── Summary ─────────────────────────────────────────────────────────────
+  for skill_dir in "$SCRIPT_DIR/skills"/*/; do
+    skill_name="$(basename "$skill_dir")"
+    install_link "$skill_dir" "$target_root/skills/$skill_name"
+    echo "✓ ${target_root##*/}/skill/$skill_name -> $skill_dir"
+  done
+
+  for hook_file in "$SCRIPT_DIR/hooks"/*; do
+    [ -f "$hook_file" ] || continue
+    hook_name="$(basename "$hook_file")"
+    install_link "$hook_file" "$target_root/hooks/$hook_name"
+    echo "✓ ${target_root##*/}/hook/$hook_name -> $hook_file"
+  done
+done
 
 echo ""
 echo "Done. Skills installed via symlinks from:"
 echo "  $SCRIPT_DIR"
 echo ""
+echo "Targets: ${TARGET_ROOTS[*]}"
 echo "To update skills, pull this repo — symlinks auto-reflect changes."
 echo "To add a new skill, run setup.sh again after adding it."

--- a/skills/aws-cost-check/SKILL.md
+++ b/skills/aws-cost-check/SKILL.md
@@ -17,7 +17,7 @@ architecture. It inspects whatever is running in the account.
 
 `<args>` may contain:
 
-- **Optional:** An AWS profile name. If not provided, check the repo's CLAUDE.md for an
+- **Optional:** An AWS profile name. If not provided, check the repo's AGENTS.md or CLAUDE.md for an
   `## AWS Cost Check` section that specifies a default profile. If no repo-level config exists
   either, fall back to the AWS CLI default profile (no `--profile` flag).
 - **Optional:** A time window like `24h`, `7d`, `mtd` (default: `mtd` = month-to-date).
@@ -34,9 +34,9 @@ Examples:
 - The `aws` CLI must be installed and the profile must be authenticated.
 - The profile needs read access to Cost Explorer, CloudWatch, and the ability to list resources
   (Lambda, DynamoDB, SQS, SNS, S3, etc.).
-- **Repo-level configuration:** Repos can define an `## AWS Cost Check` section in their CLAUDE.md
+- **Repo-level configuration:** Repos can define an `## AWS Cost Check` section in their AGENTS.md or CLAUDE.md
   to specify a default profile, authentication method (SSO vs static credentials), and alternative
-  profiles for resource enumeration. Always check CLAUDE.md before falling back to defaults.
+  profiles for resource enumeration. Always check AGENTS.md or CLAUDE.md before falling back to defaults.
 - **Region:** Resource enumeration (Lambda, DynamoDB, etc.) is per-region. This audit uses the
   profile's configured default region. Cost Explorer is global and covers all regions. If the user
   has resources in multiple regions, note this limitation in the summary.
@@ -48,7 +48,7 @@ Examples:
 First, determine the profile to use:
 
 1. If a profile was specified in `<args>`, use that.
-2. Otherwise, check the repo's CLAUDE.md for an `## AWS Cost Check` section with a default profile.
+2. Otherwise, check the repo's AGENTS.md or CLAUDE.md for an `## AWS Cost Check` section with a default profile.
 3. If neither exists, use the AWS CLI default profile (no `--profile` flag).
 
 Verify credentials:

--- a/skills/cleanup/SKILL.md
+++ b/skills/cleanup/SKILL.md
@@ -19,7 +19,8 @@ owned by other active sessions.
 
 ## Detecting Context
 
-1. **Session name:** Extract from `$PWD`. If the path contains `.claude/worktrees/<name>/`, use
+1. **Session name:** Extract from `$PWD`. If the path contains `.claude/worktrees/<name>/` or
+   `.codex/worktrees/<name>/`, use
    `<name>`. Otherwise, use `$(basename "$PWD")`.
 2. **Repo root:** Run `git rev-parse --show-toplevel`.
 3. **Current branch:** Run `git branch --show-current`.
@@ -109,14 +110,16 @@ before continuing. Do not silently skip warnings.
 5. **Handle the current session's branch:** If the current branch is a candidate for deletion
    (merged or gone-upstream) and you need to switch away from it:
 
-   **Worktree context (primary path):** If `$PWD` contains `.claude/worktrees/<name>/`, return to
-   the worktree's designated branch (`claude/<name>`) instead of the default branch. Never switch
+   **Worktree context (primary path):** If `$PWD` contains `.claude/worktrees/<name>/` or
+   `.codex/worktrees/<name>/`, return to the worktree's designated branch
+   (`claude/<name>` or `codex/<name>`) instead of the default branch. Never switch
    to the default branch in a worktree — it will fail if that branch is checked out elsewhere:
 
    ```sh
-   worktree_name=$(echo "$PWD" | sed -n 's|.*/.claude/worktrees/\([^/]*\)\(/.*\)\{0,1\}$|\1|p')
+   runtime=$(echo "$PWD" | sed -n 's|.*/\.\(claude\|codex\)/worktrees/.*|\1|p')
+   worktree_name=$(echo "$PWD" | sed -n 's|.*/\.\(claude\|codex\)/worktrees/\([^/]*\)\(/.*\)\{0,1\}$|\2|p')
    if [ -n "$worktree_name" ]; then
-     git switch "claude/${worktree_name}"
+     git switch "${runtime}/${worktree_name}"
    else
      git switch <default>
    fi

--- a/skills/preflight/SKILL.md
+++ b/skills/preflight/SKILL.md
@@ -107,13 +107,17 @@ If a PR already exists:
 
 ### 6. Worktree session conflict
 
-If `$PWD` contains `.claude/worktrees/<name>/`, check whether another session is already active in
-this worktree:
+If `$PWD` contains `.claude/worktrees/<name>/` or `.codex/worktrees/<name>/`, check whether
+another session is already active in this worktree:
 
 ```sh
-worktree_name=$(echo "$PWD" | sed -n 's|.*/.claude/worktrees/\([^/]*\)\(/.*\)\{0,1\}$|\1|p')
+worktree_name=$(echo "$PWD" | sed -n 's|.*/\.\(claude\|codex\)/worktrees/\([^/]*\)\(/.*\)\{0,1\}$|\2|p')
 if [ -n "$worktree_name" ]; then
-  project_dir=$(find ~/.claude/projects/ -maxdepth 1 -type d -name "*worktrees-${worktree_name}" | head -1)
+  for projects_root in "$HOME/.claude/projects" "$HOME/.codex/projects"; do
+    [ -d "$projects_root" ] || continue
+    project_dir=$(find "$projects_root" -maxdepth 1 -type d -name "*worktrees-${worktree_name}" | head -1)
+    [ -n "$project_dir" ] && break
+  done
   if [ -n "$project_dir" ]; then
     active_count=$(find "$project_dir" -name '*.jsonl' -mmin -5 2>/dev/null | wc -l | tr -d ' ')
   fi

--- a/skills/session-memory/SKILL.md
+++ b/skills/session-memory/SKILL.md
@@ -23,7 +23,8 @@ No shared index file is maintained, so parallel sessions never conflict.
 
 Before either mode, determine:
 
-1. **Session name:** Extract from `$PWD`. If the path contains `.claude/worktrees/<name>/`, use
+1. **Session name:** Extract from `$PWD`. If the path contains `.claude/worktrees/<name>/` or
+   `.codex/worktrees/<name>/`, use
    `<name>`. Otherwise, use the branch slug (branch name after the last `/`, e.g.,
    `user/add-oauth` → `add-oauth`).
 2. **Repo root:** Run `git rev-parse --show-toplevel`.
@@ -36,10 +37,11 @@ Before either mode, determine:
    - Otherwise, take the branch slug after the `/` (e.g., `bkonkle/add-oauth` → `add-oauth`).
 5. **Date:** Today's date as `YYYY-MM-DD`.
 6. **Session directory:** `docs/agent-sessions/YYYY-MM-DD-{session-name}-{scope}/`.
-7. **Session ID:** Parse from the Claude Code JSONL file path. The session ID is the conversation
-   UUID — look for the most recent `.jsonl` file under `~/.claude/projects/` whose encoded path
-   matches the current repo. The filename (without `.jsonl`) is the session ID. If detection fails,
-   leave as `(unknown)` and note the user can fill it in manually.
+7. **Session ID:** Parse from the agent JSONL transcript path. The session ID is the conversation
+   UUID — look for the most recent `.jsonl` file under `~/.claude/projects/` or
+   `~/.codex/projects/` whose encoded path matches the current repo. The filename (without
+   `.jsonl`) is the session ID. If detection fails, leave as `(unknown)` and note the user can fill
+   it in manually.
 
 If `docs/agent-sessions/` does not exist in the repo root, stop and tell the user the repo has not
 opted in. They can opt in by creating `docs/agent-sessions/README.md`.

--- a/skills/shepherd-to-merge/SKILL.md
+++ b/skills/shepherd-to-merge/SKILL.md
@@ -285,13 +285,13 @@ this step rather than failing.
    repo_root=$(git rev-parse --show-toplevel)
    ```
 
-   The session ID is available from the JSONL transcript filename. Claude Code exposes it
-   automatically — use the current session's UUID.
+   The session ID is available from the JSONL transcript filename in Claude Code or Codex — use the
+   current session's UUID.
 
 2. **Detect context for archive metadata:**
    ```sh
    current_branch=$(git branch --show-current)
-   worktree_name=$(echo "$PWD" | sed -n 's|.*/.claude/worktrees/\([^/]*\)\(/.*\)\{0,1\}$|\1|p')
+   worktree_name=$(echo "$PWD" | sed -n 's|.*/\.\(claude\|codex\)/worktrees/\([^/]*\)\(/.*\)\{0,1\}$|\2|p')
    agent_name="${worktree_name:-shepherd}"
    ```
 
@@ -321,11 +321,13 @@ branch after the PR merges. If the PR is still pending auto-merge, skip this ste
 
 If the state is `MERGED`:
 
-1. Switch away from the PR branch. In a worktree, use `claude/<worktree-name>`:
+1. Switch away from the PR branch. In a worktree, use `claude/<worktree-name>` or
+   `codex/<worktree-name>`:
    ```sh
-   worktree_name=$(echo "$PWD" | sed -n 's|.*/.claude/worktrees/\([^/]*\)\(/.*\)\{0,1\}$|\1|p')
+   runtime=$(echo "$PWD" | sed -n 's|.*/\.\(claude\|codex\)/worktrees/.*|\1|p')
+   worktree_name=$(echo "$PWD" | sed -n 's|.*/\.\(claude\|codex\)/worktrees/\([^/]*\)\(/.*\)\{0,1\}$|\2|p')
    if [ -n "$worktree_name" ]; then
-     git switch "claude/${worktree_name}" 2>/dev/null || true
+     git switch "${runtime}/${worktree_name}" 2>/dev/null || true
    else
      default=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||')
      [ -z "$default" ] && default="main"

--- a/statusline/statusline.sh
+++ b/statusline/statusline.sh
@@ -7,8 +7,8 @@ COST=$(echo "$input" | jq -r '.cost.total_cost_usd // 0' | xargs printf '%.2f')
 MODEL=$(echo "$input" | jq -r '.model.display_name // empty')
 
 # Extract session name from worktree path or fall back to basename
-if [[ "$DIR" =~ \.claude/worktrees/([^/]+) ]]; then
-  NAME="${BASH_REMATCH[1]}"
+if [[ "$DIR" =~ \.(claude|codex)/worktrees/([^/]+) ]]; then
+  NAME="${BASH_REMATCH[2]}"
 else
   NAME="$(basename "$DIR")"
 fi


### PR DESCRIPTION
## Summary
- update setup/install scripts to symlink skills into both `~/.claude` and `~/.codex`
- update statusline and skill docs to support both `.claude/worktrees/*` and `.codex/worktrees/*` path layouts
- adjust branch/session guidance to use runtime-specific parking branches (`claude/<name>` or `codex/<name>`)

## Testing
- `bash -n setup.sh install-skill.sh statusline/statusline.sh`
- `git diff --check`
