### PR TITLE
Add Firecrawl API skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ pull the repo and you're up to date. No reinstall needed.
 |-------|---------|-------------|
 | **AWS Cost Check** | `/aws-cost-check` | Audits your AWS account for runaway costs, forgotten resources, and free tier overages |
 | **Cleanup** | `/cleanup` | Prunes stale branches, checks for uncommitted work, reminds about session memories |
+| **Firecrawl API** | `/firecrawl-api` | Calls a hosted Firecrawl API via env vars and includes a sandbox-friendly YouTube transcript helper |
 | **Pick Up Issue** | `/pick-up-issue` | Finds an unassigned issue, claims it, implements a fix, opens a PR, and shepherds it to merge |
 | **Preflight** | `/preflight` | Validates repo identity, branch state, CI health, and open PRs before you start work |
 | **Recall** | `/recall` | Loads relevant prior context from layered session memory and archived transcripts before implementation |

--- a/skills/firecrawl-api/SKILL.md
+++ b/skills/firecrawl-api/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: firecrawl-api
+description: Use when a task should call a hosted Firecrawl HTTPS API directly instead of running a local MCP server or `npx`. Reads the base URL from `FIRECRAWL_API_URL`, authenticates with `FIRECRAWL_API_KEY`, and includes a YouTube transcript workflow that works in sandboxed environments.
+---
+
+# Firecrawl API
+
+## When to use
+- The user wants data from a hosted Firecrawl HTTPS API.
+- The environment does not have `npx`, terminal access on the target device, or a local MCP runtime.
+- The task is a Firecrawl API operation such as `scrape`, `search`, `map`, `extract`, or `crawl`.
+- The task is summarizing a YouTube video and you need transcript or caption text.
+
+## Endpoint and auth
+- Base URL: `FIRECRAWL_API_URL`
+- Auth header: `X-API-Key: $FIRECRAWL_API_KEY`
+- Required env var: `FIRECRAWL_API_URL`
+- Required env var: `FIRECRAWL_API_KEY`
+
+If either environment variable is missing, stop and say exactly that.
+
+## Core workflow
+1. Read `FIRECRAWL_API_URL` and `FIRECRAWL_API_KEY`.
+2. Pick the smallest Firecrawl endpoint that fits the task.
+3. Normalize the base URL by trimming any trailing slash before appending `/v1/...`.
+4. Use `curl -sS` for one-off requests.
+5. Return the useful fields, not the full raw payload, unless the user asked for it.
+
+## API cheat sheet
+
+Scrape:
+```sh
+curl -sS "${FIRECRAWL_API_URL%/}/v1/scrape" \
+  -H "X-API-Key: $FIRECRAWL_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"url":"https://example.com"}'
+```
+
+Search:
+```sh
+curl -sS "${FIRECRAWL_API_URL%/}/v1/search" \
+  -H "X-API-Key: $FIRECRAWL_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"site:example.com docs"}'
+```
+
+Map:
+```sh
+curl -sS "${FIRECRAWL_API_URL%/}/v1/map" \
+  -H "X-API-Key: $FIRECRAWL_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"url":"https://example.com"}'
+```
+
+Extract:
+```sh
+curl -sS "${FIRECRAWL_API_URL%/}/v1/extract" \
+  -H "X-API-Key: $FIRECRAWL_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"urls":["https://example.com"],"prompt":"Extract the main facts."}'
+```
+
+Crawl:
+```sh
+curl -sS "${FIRECRAWL_API_URL%/}/v1/crawl" \
+  -H "X-API-Key: $FIRECRAWL_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"url":"https://example.com"}'
+```
+
+## YouTube workflow
+
+Use two stages:
+
+1. Use Firecrawl `scrape` on the YouTube URL for metadata.
+   This usually gets the title, description, publish date, channel, and duration.
+
+2. Use `scripts/youtube_transcript.py` for the transcript.
+   Firecrawl often does not return the full spoken transcript from YouTube pages even when the page exposes a transcript panel.
+
+Run it like this:
+```sh
+python3 scripts/youtube_transcript.py "https://www.youtube.com/watch?v=hDn8-fK3XaU"
+```
+
+Without timestamps:
+```sh
+python3 scripts/youtube_transcript.py --no-timestamps "https://www.youtube.com/watch?v=hDn8-fK3XaU"
+```
+
+## Why the helper script is better in sandboxes
+- It does not try to install Python packages globally.
+- If `youtube-transcript-api` is missing, it creates a temporary virtualenv under the system temp directory and installs only there.
+- That is safer and more reliable in externally managed Python environments and most sandboxed workspaces.
+- If the sandbox blocks network access or virtualenv creation, the script fails cleanly and you should fall back to a metadata-only summary.
+
+## Notes
+- Preserve user-provided payload fields; only add headers and the base URL.
+- Do not echo the API key back to the user.
+- If the API returns an auth error, tell the user it likely means the key is missing, invalid, expired, or lacks scope.
+- For YouTube, do not promise a transcript until the helper script succeeds. The page can expose transcript metadata while still blocking direct caption fetches.

--- a/skills/firecrawl-api/scripts/youtube_transcript.py
+++ b/skills/firecrawl-api/scripts/youtube_transcript.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Fetch a YouTube transcript without modifying the global Python environment."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+
+BOOTSTRAP_ENV = "FIRECRAWL_API_YT_TRANSCRIPT_BOOTSTRAPPED"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Fetch a YouTube transcript using a temporary virtualenv if needed.",
+    )
+    parser.add_argument("video", help="YouTube watch URL, youtu.be URL, or video ID")
+    parser.add_argument(
+        "--language",
+        action="append",
+        dest="languages",
+        help="Preferred language code. Repeat to add fallback languages.",
+    )
+    parser.add_argument(
+        "--no-timestamps",
+        action="store_true",
+        help="Print transcript text without timestamps.",
+    )
+    return parser.parse_args()
+
+
+def extract_video_id(value: str) -> str:
+    value = value.strip()
+    if not value:
+        raise ValueError("missing YouTube URL or video ID")
+
+    parsed = urlparse(value)
+    if not parsed.scheme and not parsed.netloc:
+        return value
+
+    host = parsed.netloc.lower()
+    if host.endswith("youtu.be"):
+        video_id = parsed.path.strip("/")
+        if video_id:
+            return video_id
+    if "youtube.com" in host:
+        if parsed.path == "/watch":
+            video_id = parse_qs(parsed.query).get("v", [""])[0]
+            if video_id:
+                return video_id
+        parts = [part for part in parsed.path.split("/") if part]
+        if len(parts) >= 2 and parts[0] in {"shorts", "embed", "live"}:
+            return parts[1]
+
+    raise ValueError(f"could not extract a YouTube video ID from {value!r}")
+
+
+def ensure_dependency() -> None:
+    if importlib.util.find_spec("youtube_transcript_api") is not None:
+        return
+
+    if os.environ.get(BOOTSTRAP_ENV) == "1":
+        raise RuntimeError(
+            "youtube-transcript-api is unavailable even after bootstrapping; "
+            "the sandbox may block package installation or network access",
+        )
+
+    with tempfile.TemporaryDirectory(prefix="yt-transcript-") as tmp:
+        venv_dir = Path(tmp) / "venv"
+        subprocess.run([sys.executable, "-m", "venv", str(venv_dir)], check=True)
+        python_bin = venv_dir / "bin" / "python"
+        subprocess.run(
+            [str(python_bin), "-m", "pip", "install", "--quiet", "youtube-transcript-api"],
+            check=True,
+        )
+        env = os.environ.copy()
+        env[BOOTSTRAP_ENV] = "1"
+        result = subprocess.run([str(python_bin), __file__, *sys.argv[1:]], env=env)
+        raise SystemExit(result.returncode)
+
+
+def fetch_transcript(video_id: str, languages: list[str], include_timestamps: bool) -> int:
+    from youtube_transcript_api import YouTubeTranscriptApi  # type: ignore
+
+    api = YouTubeTranscriptApi()
+    fetched = api.fetch(video_id, languages=languages)
+    for entry in fetched:
+        if include_timestamps:
+            print(f"[{entry.start:07.2f}] {entry.text}")
+        else:
+            print(entry.text)
+    return 0
+
+
+def main() -> int:
+    args = parse_args()
+    languages = args.languages or ["en"]
+
+    try:
+        video_id = extract_video_id(args.video)
+        ensure_dependency()
+        return fetch_transcript(video_id, languages, not args.no_timestamps)
+    except subprocess.CalledProcessError as err:
+        print(f"bootstrap failed: {err}", file=sys.stderr)
+        return 1
+    except Exception as err:
+        print(f"transcript fetch failed: {err}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a new `firecrawl-api` skill that uses `FIRECRAWL_API_URL` and `FIRECRAWL_API_KEY` to point to an authenticated HTTPS endpoint
- include a sandbox-friendly YouTube transcript helper that bootstraps an ephemeral virtualenv instead of installing packages globally
- document the new skill in the README skill table

## Testing
- python3 -m py_compile skills/firecrawl-api/scripts/youtube_transcript.py
- python /Users/brandon/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/firecrawl-api
- python3 skills/firecrawl-api/scripts/youtube_transcript.py --no-timestamps https://www.youtube.com/watch?v=hDn8-fK3XaU | sed -n "1,8p"