### PR TITLE
docs(shepherd): require inline replies before resolving review threads

### DIFF
--- a/skills/pick-up-issue/SKILL.md
+++ b/skills/pick-up-issue/SKILL.md
@@ -351,6 +351,9 @@ Invoke the shepherd skill to handle review, feedback, CI, and merge:
 /shepherd-to-merge <owner>/<repo>#<pr-number>
 ```
 
+The shepherd skill requires a **public inline reply on each review comment** (what you fixed or why
+not) before resolving threads; follow that workflow end to end.
+
 Wait for the shepherd process to complete. If it encounters issues it cannot resolve, surface them
 to the user.
 

--- a/skills/shepherd-to-merge/SKILL.md
+++ b/skills/shepherd-to-merge/SKILL.md
@@ -15,8 +15,9 @@ reviews. The goal is to satisfy all merge requirements legitimately.
 
 **Review threads:** Every actionable line-level review comment (humans, Copilot, other bots) must
 receive a **public inline reply** on GitHub explaining the outcome (what changed, with enough
-pointer to find it, or why you did not change code) **before** you resolve the thread. Silent
-resolves are treated as a process failure even when the diff is correct.
+context for reviewers to find it—e.g. commit subject or SHA—or why you did not change code)
+**before** you resolve the thread. Silent resolves are treated as a process failure even when the
+diff is correct.
 
 **Multi-agent safety:** Multiple agents may be shepherding different PRs in parallel. Expect the
 base branch to move frequently as other agents merge. The rebase retry loop in step 10 handles this.
@@ -151,9 +152,12 @@ For each piece of actionable feedback (from the subagent review, human reviewers
    hunting the diff. Use the REST API on the review comment id from the comments listing, for
    example:
    ```sh
-   gh api -X POST "repos/<owner>/<repo>/pulls/<number>/comments/<comment-id>/replies" -f body='...'
+   gh api -X POST "repos/<owner>/<repo>/pulls/comments/<comment-id>/replies" -f body='...'
    ```
-   Or use equivalent GraphQL if the repo’s automation prefers it. Top-level PR comments (not tied
+   Use the numeric `id` from the PR review-comments listing (`.../pulls/<number>/comments`); the
+   reply endpoint is keyed by that comment id (`.../pulls/comments/{id}/replies`), not by embedding
+   the PR number before `comments`. Or use equivalent GraphQL if the repo’s automation prefers it.
+   Top-level PR comments (not tied
    to a line) may use `gh pr comment` or issue comment APIs; the requirement is the same — a
    **public** explanation tied to the feedback, not a silent resolve.
 5. **Resolve the review thread** only after that reply exists (when the repo uses resolved threads
@@ -190,9 +194,10 @@ reply exists on that thread** (same policy as step 6: silent resolves look like 
    ```
 
 2. For each unresolved thread: if there is not already a **public reply from you** on that thread
-   documenting the outcome (fix with enough pointer for reviewers, or explained decline), post one
-   first — e.g. `gh api -X POST "repos/<owner>/<repo>/pulls/<number>/comments/<comment-id>/replies"`
-   with `-f body='...'` — then resolve:
+   documenting the outcome (what you fixed with enough context for reviewers to verify, or an
+   explained decline), post one first — e.g.
+   `gh api -X POST "repos/<owner>/<repo>/pulls/comments/<comment-id>/replies"` with `-f body='...'`
+   — then resolve:
    ```sh
    gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "<thread-id>"}) { thread { isResolved } } }'
    ```

--- a/skills/shepherd-to-merge/SKILL.md
+++ b/skills/shepherd-to-merge/SKILL.md
@@ -152,11 +152,12 @@ For each piece of actionable feedback (from the subagent review, human reviewers
    hunting the diff. Use the REST API on the review comment id from the comments listing, for
    example:
    ```sh
-   gh api -X POST "repos/<owner>/<repo>/pulls/comments/<comment-id>/replies" -f body='...'
+   gh api -X POST "repos/<owner>/<repo>/pulls/<number>/comments/<comment-id>/replies" -f body='...'
    ```
-   Use the numeric `id` from the PR review-comments listing (`.../pulls/<number>/comments`); the
-   reply endpoint is keyed by that comment id (`.../pulls/comments/{id}/replies`), not by embedding
-   the PR number before `comments`. Or use equivalent GraphQL if the repo’s automation prefers it.
+   Use the numeric `id` from the PR review-comments listing (`GET .../pulls/<number>/comments`).
+   Note: a comment’s `url` field uses `.../pulls/comments/{id}` for **GET**, but **creating a
+   reply** requires the pull number in the path (`.../pulls/<number>/comments/<comment-id>/replies`);
+   omitting `<number>` returns 404. Or use equivalent GraphQL if the repo’s automation prefers it.
    Top-level PR comments (not tied
    to a line) may use `gh pr comment` or issue comment APIs; the requirement is the same — a
    **public** explanation tied to the feedback, not a silent resolve.
@@ -196,8 +197,8 @@ reply exists on that thread** (same policy as step 6: silent resolves look like 
 2. For each unresolved thread: if there is not already a **public reply from you** on that thread
    documenting the outcome (what you fixed with enough context for reviewers to verify, or an
    explained decline), post one first — e.g.
-   `gh api -X POST "repos/<owner>/<repo>/pulls/comments/<comment-id>/replies"` with `-f body='...'`
-   — then resolve:
+   `gh api -X POST "repos/<owner>/<repo>/pulls/<number>/comments/<comment-id>/replies"` with
+   `-f body='...'` — then resolve:
    ```sh
    gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "<thread-id>"}) { thread { isResolved } } }'
    ```

--- a/skills/shepherd-to-merge/SKILL.md
+++ b/skills/shepherd-to-merge/SKILL.md
@@ -162,10 +162,13 @@ For each piece of actionable feedback (from the subagent review, human reviewers
    to a line) may use `gh pr comment` or issue comment APIs; the requirement is the same — a
    **public** explanation tied to the feedback, not a silent resolve.
 5. **Resolve the review thread** only after that reply exists (when the repo uses resolved threads
-   as a merge gate). Find the thread ID from the comment’s `node_id`, then resolve:
+   as a merge gate). `PullRequestReviewComment` no longer exposes `pullRequestReviewThread` on the
+   `node(id: …)` query — list `reviewThreads` on the pull request and pick the thread whose
+   `comments` include that comment’s GraphQL `node_id` from the REST listing:
    ```sh
-   # Get the thread ID from a review comment's node_id
-   gh api graphql -f query='query { node(id: "<comment-node-id>") { ... on PullRequestReviewComment { pullRequestReviewThread { id } } } }' --jq '.data.node.pullRequestReviewThread.id'
+   # thread id (PRRT_...) for a review comment's node_id (PRRC_... from REST)
+   gh api graphql -f query='query { repository(owner: "<owner>", name: "<repo>") { pullRequest(number: <number>) { reviewThreads(first: 100) { nodes { id comments(first: 50) { nodes { id } } } } } } } }' \
+     --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select([.comments.nodes[].id] | index("<comment-node-id>")) | .id][0]'
 
    # Resolve the thread
    gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "<thread-id>"}) { thread { isResolved } } }'

--- a/skills/shepherd-to-merge/SKILL.md
+++ b/skills/shepherd-to-merge/SKILL.md
@@ -13,6 +13,11 @@ protection rules or security constraints.
 **Important:** Never use admin privileges to bypass branch protections, force-merge, or dismiss
 reviews. The goal is to satisfy all merge requirements legitimately.
 
+**Review threads:** Every actionable line-level review comment (humans, Copilot, other bots) must
+receive a **public inline reply** on GitHub explaining the outcome (what changed, with enough
+pointer to find it, or why you did not change code) **before** you resolve the thread. Silent
+resolves are treated as a process failure even when the diff is correct.
+
 **Multi-agent safety:** Multiple agents may be shepherding different PRs in parallel. Expect the
 base branch to move frequently as other agents merge. The rebase retry loop in step 10 handles this.
 Each agent works on its own PR branch and does not modify branches belonging to other sessions.
@@ -123,12 +128,36 @@ gh api repos/<owner>/<repo>/pulls/<number>/comments --jq '.[] | {id, node_id, pa
 gh api repos/<owner>/<repo>/pulls/<number>/reviews --jq '.[] | {id, node_id, state, body, user: .user.login}'
 ```
 
+**Public reply before resolve (merge shepherding policy):** Do not treat a review thread as “done”
+without a **public inline reply on GitHub** on that comment or thread. Resolving threads with no
+reply looks like ignored feedback even when the code was fixed; many repos (including companion
+`AGENTS.md` guidance) expect a short explanation on the thread when it is resolved. This applies to
+**every actionable PR review comment**, including Copilot and other bots: after you fix code **or**
+after you decide not to change behavior, post the reply **first**, then resolve (on repos that use
+resolved threads as a merge gate). Declining a suggestion is fine when explained — the reply is
+still required.
+
 For each piece of actionable feedback (from the subagent review, human reviewers, or Copilot):
 
-1. **Fix the issue** in the local checkout — edit the file, make the correction
-2. **Commit the fix** with a clear message referencing the feedback
-3. **Resolve the review thread** if it's a PR review comment thread. First, find the thread ID for
-   the comment, then resolve it:
+1. **Fix the issue** in the local checkout — edit the file, make the correction (or decide not to
+   change behavior and prepare the explanation for item 4 below).
+2. **Commit the fix** with a clear message referencing the feedback (skip a code commit only when
+   the outcome is explanation-only, e.g. out of scope or incorrect suggestion).
+3. **Push** the branch so the updated diff (if any) is visible on GitHub before you reply.
+4. **Post an inline reply** on the review comment or thread **before** resolving it. The reply must
+   state clearly **what** you did (e.g. behavior changed, commit subject or SHA so reviewers need
+   not diff-hunt) **or** **why** you did not implement the suggestion (out of scope, wrong
+   suggestion, intentional tradeoff) with enough detail for a reviewer to understand without
+   hunting the diff. Use the REST API on the review comment id from the comments listing, for
+   example:
+   ```sh
+   gh api -X POST "repos/<owner>/<repo>/pulls/<number>/comments/<comment-id>/replies" -f body='...'
+   ```
+   Or use equivalent GraphQL if the repo’s automation prefers it. Top-level PR comments (not tied
+   to a line) may use `gh pr comment` or issue comment APIs; the requirement is the same — a
+   **public** explanation tied to the feedback, not a silent resolve.
+5. **Resolve the review thread** only after that reply exists (when the repo uses resolved threads
+   as a merge gate). Find the thread ID from the comment’s `node_id`, then resolve:
    ```sh
    # Get the thread ID from a review comment's node_id
    gh api graphql -f query='query { node(id: "<comment-node-id>") { ... on PullRequestReviewComment { pullRequestReviewThread { id } } } }' --jq '.data.node.pullRequestReviewThread.id'
@@ -136,15 +165,16 @@ For each piece of actionable feedback (from the subagent review, human reviewers
    # Resolve the thread
    gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "<thread-id>"}) { thread { isResolved } } }'
    ```
-4. **Push the fixes** to the PR branch
 
-If any feedback requires clarification or is outside the scope of the PR, leave a reply comment
-explaining why it wasn't addressed rather than ignoring it.
+If any feedback requires clarification or is outside the scope of the PR, use item 4 to explain why
+it was not implemented — **then** resolve the thread if appropriate; do not resolve without that
+public reply.
 
 ### 7. Resolve all review threads
 
 Before proceeding, ensure every review thread on the PR is resolved. Unresolved threads block
-auto-merge on repos with branch protection.
+auto-merge on repos with branch protection. **Do not resolve any thread until step 6’s public inline
+reply exists on that thread** (same policy as step 6: silent resolves look like ignored feedback).
 
 1. **List all review threads** and check for unresolved ones:
    ```sh
@@ -159,12 +189,17 @@ auto-merge on repos with branch protection.
    }' --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)'
    ```
 
-2. For each unresolved thread where the feedback was addressed in a commit, resolve it:
+2. For each unresolved thread: if there is not already a **public reply from you** on that thread
+   documenting the outcome (fix with enough pointer for reviewers, or explained decline), post one
+   first — e.g. `gh api -X POST "repos/<owner>/<repo>/pulls/<number>/comments/<comment-id>/replies"`
+   with `-f body='...'` — then resolve:
    ```sh
    gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "<thread-id>"}) { thread { isResolved } } }'
    ```
 
-3. For threads where the feedback was not addressed, leave a reply comment explaining why.
+3. Threads where the feedback was not implemented still require that explanatory reply before
+   resolve (out of scope, wrong suggestion, tradeoff); declining with explanation satisfies the
+   policy — resolving without any reply does not.
 
 ### 8. Re-review after fixes
 
@@ -256,8 +291,9 @@ is needed.
 **Copilot review note:** GitHub Copilot provides a single automated review when the PR is first
 created. It does **not** re-review after subsequent pushes. Do not request new Copilot reviews or
 wait for Copilot to review new commits — it won't happen. Copilot review is not a merge gate.
-If Copilot left review comments, treat them like any other review thread: address or respond to
-the feedback and resolve the thread. If `mergeStateStatus` remains `BLOCKED` after all threads
+If Copilot left review comments, treat them like any other review thread: address or respond with
+a **public inline reply**, then resolve the thread — never resolve Copilot (or any) threads without
+that reply. If `mergeStateStatus` remains `BLOCKED` after all threads
 are resolved and CI is green, the issue is likely unrelated to Copilot (check for ruleset
 requirements, workflow file scope restrictions, or other branch protection rules).
 
@@ -267,6 +303,8 @@ Print a summary:
 
 - **PR:** title and URL
 - **Review:** findings from the subagent review
+- **Review threads:** confirm each thread got an inline reply (implementation or explained decline)
+  before resolve
 - **Fixes applied:** list of commits pushed to address feedback
 - **CI status:** all checks passing
 - **Merge:** auto-merge enabled, will merge when all requirements are met


### PR DESCRIPTION
## Summary

Tightens **merge shepherding** so agents never treat a PR review thread as finished without a **public inline reply on GitHub** first. The skill still follows the same legitimate merge path (no admin bypass, Copilot still does not re-review); it adds a required **communication** step so resolution does not look like ignored feedback.

## Problem

When automation fixes code and resolves review threads without commenting, reviewers and branch policies see a green thread but no signal *why* it was resolved—easy to read as “ignored.” Many repos (including companion `AGENTS.md`-style rules) expect a short, thread-visible explanation when resolving discussion.

## What changed

### `shepherd-to-merge`

- **Policy** (also summarized near the top of the skill): for every actionable line-level comment (humans, Copilot, other bots), post an inline reply that either explains **what** changed (enough context to verify—e.g. commit subject or SHA) or **why** something was not done (out of scope, wrong suggestion, tradeoff). **Then** resolve the thread if the repo gates on resolved threads.
- **Step ordering**: keep **fix → commit → push**, then **reply → resolve** so replies can reference commits already on the PR.
- **REST hint**: document `gh api -X POST "repos/<owner>/<repo>/pulls/<number>/comments/<comment-id>/replies"` and note that review comment **GET** URLs use `pulls/comments/{id}` while **creating a reply** still requires the **pull number** in the path (verified against the live API; omitting it 404s).
- **GraphQL**: replace the outdated `node(id: …) { … pullRequestReviewThread { id } }` pattern—`pullRequestReviewThread` is not on `PullRequestReviewComment` in the current schema—with **`reviewThreads` on the PR + `jq`** to find the thread id for a given comment `node_id`.

### `pick-up-issue`

- Aligns the handoff to `/shepherd-to-merge` with the same **reply-before-resolve** expectation so the lifecycle skill and the shepherd skill stay consistent.

## Verification

- Confirmed GitHub REST behavior for review replies on this PR (`POST` with vs without PR number in the path).
- Confirmed `reviewThreads` + `jq` thread lookup against the GraphQL API.

## Out of scope

- No change to merge gates, Copilot behavior, or admin/branch-protection bypass rules (still explicitly disallowed).
