### PR TITLE
docs(aws-cost-check): improve linked-account attribution guidance

### DIFF
--- a/skills/aws-cost-check/SKILL.md
+++ b/skills/aws-cost-check/SKILL.md
@@ -50,6 +50,11 @@ Examples:
   (`Operation not permitted`). **SSO** sessions typically use `~/.aws/sso/cache`; other cached
   credential material may use `~/.aws/cli/cache`. If either path cannot be written, rerun AWS
   commands outside the sandbox / with elevated permissions and document that adjustment.
+- **IAM / permission sets:** In `bkonkle-dev/apps`, the payer `billing-admin` SSO inline policy
+  includes statement `AwsCostCheckResourceDiscoveryReadOnly` in `infra/management/sso_billing.tf`.
+  After Terraform changes to that permission set, the user must start a **new** SSO session
+  (`aws sso login --profile <profile>`) before retesting; Identity Center does not refresh
+  in-flight credentials.
 
 ## Steps
 
@@ -345,8 +350,10 @@ aws route53domains list-domains --profile <profile> --region us-east-1 --output 
 
 Each hosted zone costs $0.50/month. No free tier for hosted zones.
 
-Also check for health checks and registered domains when permissions allow. If these commands are
-denied, report the access gap explicitly because it weakens attribution for Route 53 charges.
+Also check for health checks and registered domains when permissions allow. `route53domains`
+requires **`route53domains:ListDomains`** (API is only offered from **`us-east-1`** in the CLI). If
+these commands are denied, report the access gap explicitly because it weakens attribution for
+Route 53 charges.
 
 #### 3k. CloudWatch Alarms
 
@@ -383,7 +390,7 @@ aws budgets describe-budgets --profile <profile> --account-id <account-id> --out
 
 List budget names, time units, and limits.
 
-#### 3n. EC2 / ECS / EKS / RDS
+#### 3n. EC2 / ECS / RDS
 
 Quick check for running compute that might be burning money:
 
@@ -399,8 +406,37 @@ aws rds describe-db-instances --profile <profile> \
   --output json 2>/dev/null
 ```
 
+When **EC2 - Other** (EBS) or **VPC** (public IPv4) spend shows up in Cost Explorer but running
+instance inventory is thin, also list **EBS volumes** and **Elastic IPs** (stopped instances and
+orphan volumes/EIPs are common drivers):
+
+```sh
+aws ec2 describe-volumes --profile <profile> \
+  --query 'Volumes[].{Id:VolumeId,State:State,Size:Size,Type:VolumeType,Attachments:Attachments}' \
+  --output json
+
+aws ec2 describe-addresses --profile <profile> --output json
+```
+
 Flag any **running EC2 instances**, active ECS clusters, or RDS instances — these are typically the
 most expensive resources.
+
+#### 3o. Secrets Manager (when billed)
+
+If **AWS Secrets Manager** appears in Cost Explorer for this account, list secret **metadata** (not
+values) to correlate monthly per-secret charges:
+
+```sh
+aws secretsmanager list-secrets --profile <profile> --output json
+```
+
+#### 3p. EFS (when billed)
+
+If **Amazon EFS** appears in Cost Explorer for this account:
+
+```sh
+aws efs describe-file-systems --profile <profile> --output json
+```
 
 ### 4. Free tier dashboard
 

--- a/skills/aws-cost-check/SKILL.md
+++ b/skills/aws-cost-check/SKILL.md
@@ -46,9 +46,10 @@ Examples:
 - **Region + account scope:** Cost Explorer is global and may include multiple linked accounts and
   regions. Resource enumeration is per-account/per-region. Always identify these scope boundaries in
   the final attribution section.
-- **Cursor/Codex sandbox note:** In tool-sandboxed environments, AWS CLI SSO token cache writes may
-  fail (`Operation not permitted` under `~/.aws/cli/cache`). If this happens, rerun AWS commands
-  outside sandbox / with elevated permissions and document that adjustment.
+- **Cursor/Codex sandbox note:** In tool-sandboxed environments, AWS CLI cache writes may fail
+  (`Operation not permitted`). **SSO** sessions typically use `~/.aws/sso/cache`; other cached
+  credential material may use `~/.aws/cli/cache`. If either path cannot be written, rerun AWS
+  commands outside the sandbox / with elevated permissions and document that adjustment.
 
 ## Steps
 
@@ -76,8 +77,8 @@ If this fails with a credentials error:
 Print the account ID, assumed role, and default region so the user knows which account and region are
 being audited.
 
-If the audit runs in Cursor/Codex and STS fails with cache permission errors, rerun with elevated
-tool permissions before continuing.
+If the audit runs in Cursor/Codex and STS fails with cache permission errors (often under
+`~/.aws/sso/cache` or `~/.aws/cli/cache`), rerun with elevated tool permissions before continuing.
 
 ### 2. Cost Explorer — top-level billing
 

--- a/skills/aws-cost-check/SKILL.md
+++ b/skills/aws-cost-check/SKILL.md
@@ -6,9 +6,9 @@ disable-model-invocation: true
 
 # AWS Cost Check
 
-Perform a thorough cost and health audit of an AWS account. Discovers all active services and
+Perform a thorough cost and health audit of an AWS account. Discovers active services and
 resources, checks for runaway costs or loops, flags resources approaching free tier limits, and
-provides a full cost breakdown.
+provides a cost breakdown with clear attribution gaps.
 
 This is a **generic, discovery-driven** audit — it does not assume any particular application
 architecture. It inspects whatever is running in the account.
@@ -37,12 +37,18 @@ Examples:
 - If possible, the profile should also be able to read Route 53 global resources, API Gateway
   custom domains, Budgets, and KMS key metadata. If any of these calls are denied, report the
   exact permission gap in the summary instead of silently skipping it.
-- **Repo-level configuration:** Repos can define an `## AWS Cost Check` section in their AGENTS.md or CLAUDE.md
-  to specify a default profile, authentication method (SSO vs static credentials), and alternative
-  profiles for resource enumeration. Always check AGENTS.md or CLAUDE.md before falling back to defaults.
-- **Region:** Resource enumeration (Lambda, DynamoDB, etc.) is per-region. This audit uses the
-  profile's configured default region. Cost Explorer is global and covers all regions. If the user
-  has resources in multiple regions, note this limitation in the summary.
+- **Repo-level configuration:** Repos can define an `## AWS Cost Check` section in AGENTS.md or
+  CLAUDE.md to specify:
+  - default payer profile
+  - auth command (for example SSO login)
+  - optional linked-account read-only profiles for deeper resource enumeration
+  Always check AGENTS.md or CLAUDE.md before falling back to defaults.
+- **Region + account scope:** Cost Explorer is global and may include multiple linked accounts and
+  regions. Resource enumeration is per-account/per-region. Always identify these scope boundaries in
+  the final attribution section.
+- **Cursor/Codex sandbox note:** In tool-sandboxed environments, AWS CLI SSO token cache writes may
+  fail (`Operation not permitted` under `~/.aws/cli/cache`). If this happens, rerun AWS commands
+  outside sandbox / with elevated permissions and document that adjustment.
 
 ## Steps
 
@@ -69,6 +75,9 @@ If this fails with a credentials error:
 
 Print the account ID, assumed role, and default region so the user knows which account and region are
 being audited.
+
+If the audit runs in Cursor/Codex and STS fails with cache permission errors, rerun with elevated
+tool permissions before continuing.
 
 ### 2. Cost Explorer — top-level billing
 
@@ -117,10 +126,33 @@ aws ce get-cost-and-usage --profile <profile> \
   --output json
 ```
 
+Also fetch **linked account** and **region** splits so you know where to enumerate resources next:
+
+```sh
+aws ce get-cost-and-usage --profile <profile> \
+  --time-period Start=<start>,End=<end> \
+  --granularity MONTHLY \
+  --metrics UnblendedCost \
+  --group-by Type=DIMENSION,Key=LINKED_ACCOUNT \
+  --output json
+
+aws ce get-cost-and-usage --profile <profile> \
+  --time-period Start=<start>,End=<end> \
+  --granularity MONTHLY \
+  --metrics UnblendedCost \
+  --group-by Type=DIMENSION,Key=REGION \
+  --output json
+```
+
+If a non-payer linked account drives spend, either:
+- switch to a configured linked-account read-only profile and enumerate there, or
+- explicitly call out attribution risk if that profile is unavailable.
+
 ### 3. Discover active resources
 
 Enumerate what's actually running in the account. For each service below, list resources and collect
-metrics. **Skip services that return empty results** — only report on what exists.
+metrics. Prioritize services with meaningful spend (for example, >$0.01 in window) before deep dives.
+**Skip services that return empty results** — only report on what exists.
 
 #### 3a. Lambda functions
 
@@ -248,7 +280,8 @@ aws cloudwatch get-metric-statistics --profile <profile> \
 ```
 
 Do not stop at `StandardStorage` if Cost Explorer shows S3 spend but the metric is zero. Check the
-bucket region and inspect other storage classes or Cost Explorer usage types.
+bucket region and inspect other storage classes or Cost Explorer usage types. Remember `BucketSizeBytes`
+often lags and can be empty for new/low-activity buckets; do not assume zero-cost from empty datapoints.
 
 **Free tier:** 5 GB storage, 20,000 GET, 2,000 PUT for 12 months.
 
@@ -399,7 +432,7 @@ Flag anything unusual:
 - **Alarms firing:** Any CloudWatch alarm in ALARM state
 - **Spend without matching inventory:** A billed service has meaningful cost but the current
   resource inventory is empty or near-empty; usually means deleted earlier-in-window resources,
-  global resources, cross-region resources, or missing permissions
+  linked-account resources, global resources, cross-region resources, or missing permissions
 
 ### 6. Print summary
 
@@ -415,7 +448,12 @@ Present the results in clear sections:
    - 🔴 Critical: runaway costs, ALARM state, throttling
    - 🟡 Warning: approaching free tier limits, error rates > 10%, DLQ buildup
    - 🟢 OK: everything within normal parameters
-8. **Estimated Cost Without Free Tier** — what the bill would be at full pricing, so the user
-   understands their actual resource consumption
+8. **Estimated Cost Without Free Tier** — what the bill would be at full pricing, or state that
+   billed cost is already near full pricing when free-tier impact is immaterial
 9. **Attribution Gaps** — any denied API calls, cross-region blind spots, or billed services whose
    current inventory did not explain the spend
+
+In **Attribution Gaps**, always include:
+- permission-denied APIs (verbatim action names)
+- linked-account blind spots (if cost is in an account you could not enumerate)
+- region blind spots (if non-default regions were billed but not enumerated)


### PR DESCRIPTION
## Summary
- add explicit linked-account and region cost splits before resource enumeration
- document sandboxed AWS CLI SSO cache permission failures and required elevated reruns
- strengthen attribution-gap reporting requirements for denied APIs and scope blind spots

## Test plan
- [x] Reviewed updated `skills/aws-cost-check/SKILL.md` for instruction flow and consistency
- [x] Confirmed new guidance addresses real failure modes seen in a live `/aws-cost-check` run (linked-account spend mismatch, sandbox auth cache errors, sparse S3 size metrics)
- [x] Dry-run the updated skill end-to-end in a separate repo context