### PR TITLE
feat(architecture-diagrams): add reusable React Flow + ELK diagram skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ pull the repo and you're up to date. No reinstall needed.
 
 | Skill | Command | What it does |
 |-------|---------|-------------|
+| **Architecture Diagrams** | `/architecture-diagrams` | Builds an interactive, auto-laid-out architecture docs page (React Flow + ELK); portable to TanStack Start, Next.js, or any React app |
 | **AWS Cost Check** | `/aws-cost-check` | Audits your AWS account for runaway costs, forgotten resources, and free tier overages |
 | **Cleanup** | `/cleanup` | Prunes stale branches, checks for uncommitted work, reminds about session memories |
 | **Pick Up Issue** | `/pick-up-issue` | Finds an unassigned issue, claims it, implements a fix, opens a PR, and shepherds it to merge |

--- a/skills/architecture-diagrams/SKILL.md
+++ b/skills/architecture-diagrams/SKILL.md
@@ -1,16 +1,16 @@
 ---
 name: architecture-diagrams
-description: Build an interactive, layered architecture-diagram docs page (React Flow + ELK auto-layout) — the Homunculus /docs experience, portable to TanStack Start, Next.js, or any React app
+description: Build an interactive, layered architecture-diagram docs page (React Flow + ELK auto-layout), portable to TanStack Start, Next.js, or any React app
 argument-hint: [target app path]
 ---
 
 # Architecture Diagrams
 
 Build a polished, interactive **architecture diagram docs page** — a sidebar of diagrams, an
-auto-laid-out canvas with zoom/pan/minimap, themed nodes, routed edges, and a legend. This is the
-system behind Homunculus `/docs`. It is intentionally framework-agnostic: the rendering toolkit is
-plain React + two libraries, so the same code drops into **TanStack Start**, **Next.js (App or
-Pages Router)**, Vite SPA, Remix, or any React 18/19 app.
+auto-laid-out canvas with zoom/pan/minimap, themed nodes, routed edges, and a legend. It is
+intentionally framework-agnostic: the rendering toolkit is plain React + two libraries, so the same
+code drops into **TanStack Start**, **Next.js (App or Pages Router)**, Vite SPA, Remix, or any
+React 18/19 app.
 
 The core idea: **callers only write semantic data** (a list of nodes and edges). The toolkit owns
 layout, positioning, styling, and theming. Authoring a new diagram is editing one data file — never
@@ -224,19 +224,19 @@ themes cleanly and supports dark mode without a single dark-mode branch.
 The stylesheet reads host theme tokens with standalone fallbacks:
 
 ```css
---rfd-ink:    var(--pg-ink, #0f172a);     /* text */
---rfd-card:   var(--pg-shell, #ffffff);   /* node background */
---rfd-border: var(--pg-border, rgba(100,116,139,0.22));
---rfd-edge:   var(--pg-subtle, #64748b);  /* default edge */
+--rfd-ink:    var(--app-ink, #0f172a);     /* text */
+--rfd-card:   var(--app-surface, #ffffff); /* node background */
+--rfd-border: var(--app-border, rgba(100,116,139,0.22));
+--rfd-edge:   var(--app-subtle, #64748b);  /* default edge */
 ```
 
-**Portability:** the `--pg-*` names are Photon Grove's design tokens (set by
-`@photon-grove/react-ui`'s ThemeProvider). In another app, either (a) define `--pg-ink`,
-`--pg-shell`, `--pg-border`, `--pg-subtle`, `--pg-hover`, `--pg-font-sans` on a wrapping element, or
-(b) rename the `var(--pg-*, …)` references in `stylesheet.ts` to your own token names. The hard-coded
-fallbacks mean it looks correct out of the box even with no tokens defined. Dark mode "just works"
-if your tokens flip — the layout uses `color-mix(...)` against `--rfd-ink`/`--rfd-card` rather than
-fixed light colors.
+**Portability:** the `--app-*` names are placeholder host tokens you map to whatever design system
+the app already uses. Either (a) define `--app-ink`, `--app-surface`, `--app-border`, `--app-subtle`,
+`--app-hover`, `--app-font-sans` (and optionally `--app-accent`) on a wrapping element, or (b) rename
+the `var(--app-*, …)` references in `stylesheet.ts` to your own token names. The hard-coded fallbacks
+mean it looks correct out of the box even with no tokens defined. Dark mode "just works" if your
+tokens flip — the layout uses `color-mix(...)` against `--rfd-ink`/`--rfd-card` rather than fixed
+light colors.
 
 ### Node anatomy
 
@@ -300,7 +300,7 @@ When standing this up in a project:
 1. `npm i @xyflow/react elkjs` (confirm React 18/19 present).
 2. Copy `reference/src/` into the project; fix the import of React Flow's stylesheet
    (`@xyflow/react/dist/style.css`) is already done inside `DiagramCanvas.tsx`.
-3. Decide theming: define `--pg-*` tokens on a wrapper, or rename to your tokens in
+3. Decide theming: define `--app-*` tokens on a wrapper, or rename to your tokens in
    `stylesheet.ts`. Confirm light/dark both read well.
 4. Write 1 diagram, mount `<DiagramViewer>` on a **client** route with a real height.
 5. Verify: canvas renders, you can pan/zoom, edges route around nodes, labels sit in gaps, the
@@ -318,7 +318,7 @@ When standing this up in a project:
 | Edges cut through nodes | Not consuming ELK routes | Use the custom `OrthogonalEdge` + route data from `runElkLayout` |
 | Boundary-internal edge floats away from its nodes | Boundary-local coords not translated | Offset edge waypoints by the lowest-common-ancestor boundary origin (bundled layout does this) |
 | Stale/unanchored edges after switching diagrams | Canvas reused, not remounted | Key the canvas by `spec.id` |
-| Colors look wrong in dark mode | Host tokens missing/not flipping | Define `--pg-*` (or your) tokens that flip with theme; fallbacks are light-only |
+| Colors look wrong in dark mode | Host tokens missing/not flipping | Define `--app-*` (or your) tokens that flip with theme; fallbacks are light-only |
 | Diagram sprawls into a thin band | Too many sibling nodes in one layer | Group with boundaries; tune `elk.aspectRatio` / split the diagram |
 
 ## Reference files
@@ -339,8 +339,8 @@ When standing this up in a project:
 - `Legend.tsx` — auto-derived legend
 - `examples/cqrs-event-sourcing.ts` — a complete example spec to copy from
 
-> Source of truth in the Photon Grove monorepo: `packages/react-flow-diagrams`. If you're working
-> *inside* `photon-grove/apps`, import `@photon-grove/react-flow-diagrams` directly instead of
-> copying. The `reference/` copy exists so this skill works in any other repo.
+> If your project already publishes this toolkit as an internal package, import from that package
+> instead of copying. The `reference/` copy exists so the skill is self-contained and works in any
+> repo with no prior setup.
 </content>
 </invoke>

--- a/skills/architecture-diagrams/SKILL.md
+++ b/skills/architecture-diagrams/SKILL.md
@@ -74,8 +74,15 @@ project (e.g. `src/lib/diagrams/` or a local package), then write diagram data f
 1. **Install deps**: `npm i @xyflow/react elkjs`.
 2. **Copy the toolkit**: copy `reference/src/` from this skill into your project (keep the folder
    structure — `theme/`, `layout/`, `nodes/`, and the top-level files).
-3. **Write a diagram** as a typed `DiagramSpec` data file (see `reference/examples/`).
-4. **Register diagrams** in an array and mount the viewer on a **client-rendered** route:
+3. **Import React Flow's base stylesheet once, at your app's global entry** (not inside a
+   component — see Rendering below):
+
+   ```ts
+   import '@xyflow/react/dist/style.css'
+   ```
+
+4. **Write a diagram** as a typed `DiagramSpec` data file (see `reference/examples/`).
+5. **Register diagrams** in an array and mount the viewer on a **client-rendered** route:
 
    ```tsx
    import {DiagramViewer} from '@/lib/diagrams'
@@ -90,7 +97,7 @@ project (e.g. `src/lib/diagrams/` or a local package), then write diagram data f
    }
    ```
 
-5. **Give the viewer a real height.** It fills its parent (`height: 100%`), so the wrapper must have
+6. **Give the viewer a real height.** It fills its parent (`height: 100%`), so the wrapper must have
    a concrete height (`100dvh`, a flex child, etc.) or the canvas collapses to 0px.
 
 ## The data contract (`DiagramSpec`)
@@ -164,6 +171,20 @@ import dynamic from 'next/dynamic'
 const DocsScreen = dynamic(() => import('@/features/docs/DocsScreen'), {ssr: false})
 export default function Page() { return <DocsScreen /> }
 ```
+
+### Import React Flow's base stylesheet at the app entry
+
+React Flow ships a base stylesheet (`@xyflow/react/dist/style.css`) that the canvas needs. Import it
+**once, from your app's global entry** — the toolkit deliberately does *not* import it inside a
+component, because a global CSS import inside a component breaks Next.js builds:
+
+- **Next.js App Router**: `import '@xyflow/react/dist/style.css'` in `app/layout.tsx`.
+- **Next.js Pages Router**: import it in `pages/_app.tsx`.
+- **TanStack Start / Vite / Remix**: import it in the root route/layout or your app entry (e.g.
+  `main.tsx`) — anywhere global is fine since they don't enforce App Router's restriction.
+
+The toolkit's own visual stylesheet (`RFD_STYLESHEET`) is separate and *is* injected automatically
+by `DiagramViewer`; only React Flow's base CSS is your responsibility.
 
 ### Remount on switch (subtle but important)
 
@@ -298,16 +319,16 @@ features/docs/
 When standing this up in a project:
 
 1. `npm i @xyflow/react elkjs` (confirm React 18/19 present).
-2. Copy `reference/src/` into the project. The React Flow stylesheet import
-   (`@xyflow/react/dist/style.css`) is already handled inside `DiagramCanvas.tsx`, so there's
-   nothing extra to wire up.
-3. Decide theming: define `--app-*` tokens on a wrapper, or rename to your tokens in
+2. Copy `reference/src/` into the project.
+3. Import `@xyflow/react/dist/style.css` once at your app's global entry (root layout / `_app` /
+   app entry — see Rendering). Don't import it inside a component.
+4. Decide theming: define `--app-*` tokens on a wrapper, or rename to your tokens in
    `stylesheet.ts`. Confirm light/dark both read well.
-4. Write 1 diagram, mount `<DiagramViewer>` on a **client** route with a real height.
-5. Verify: canvas renders, you can pan/zoom, edges route around nodes, labels sit in gaps, the
+5. Write 1 diagram, mount `<DiagramViewer>` on a **client** route with a real height.
+6. Verify: canvas renders, you can pan/zoom, edges route around nodes, labels sit in gaps, the
    minimap colors match domains, switching diagrams redraws cleanly.
-6. Add the rest of the diagrams as data files; register in the index array.
-7. Update the app's docs/README index to point at the new `/docs` route.
+7. Add the rest of the diagrams as data files; register in the index array.
+8. Update the app's docs/README index to point at the new docs route.
 
 ## Pitfalls
 
@@ -343,5 +364,3 @@ When standing this up in a project:
 > If your project already publishes this toolkit as an internal package, import from that package
 > instead of copying. The `reference/` copy exists so the skill is self-contained and works in any
 > repo with no prior setup.
-</content>
-</invoke>

--- a/skills/architecture-diagrams/SKILL.md
+++ b/skills/architecture-diagrams/SKILL.md
@@ -1,0 +1,346 @@
+---
+name: architecture-diagrams
+description: Build an interactive, layered architecture-diagram docs page (React Flow + ELK auto-layout) — the Homunculus /docs experience, portable to TanStack Start, Next.js, or any React app
+argument-hint: [target app path]
+---
+
+# Architecture Diagrams
+
+Build a polished, interactive **architecture diagram docs page** — a sidebar of diagrams, an
+auto-laid-out canvas with zoom/pan/minimap, themed nodes, routed edges, and a legend. This is the
+system behind Homunculus `/docs`. It is intentionally framework-agnostic: the rendering toolkit is
+plain React + two libraries, so the same code drops into **TanStack Start**, **Next.js (App or
+Pages Router)**, Vite SPA, Remix, or any React 18/19 app.
+
+The core idea: **callers only write semantic data** (a list of nodes and edges). The toolkit owns
+layout, positioning, styling, and theming. Authoring a new diagram is editing one data file — never
+touching coordinates or CSS.
+
+## When to use this skill
+
+- A project needs living architecture docs (system landscape, data flow, CQRS/event sourcing, auth,
+  routing, pipeline stages, domain model).
+- You want diagrams that **auto-layout** so authors never hand-place boxes.
+- You want diagrams checked into the repo as typed data (reviewable in PRs, no external tool).
+
+If you only need a single static picture, a Mermaid block in Markdown is lighter. Reach for this
+when you want an interactive, multi-diagram, branded experience that stays maintainable as the
+system grows.
+
+## The stack
+
+Two runtime dependencies. Everything else is hand-written and bundled in `reference/`.
+
+| Library | Version | Role |
+|---|---|---|
+| [`@xyflow/react`](https://reactflow.dev) (React Flow) | `^12.8` | SVG canvas: nodes, edges, zoom/pan, minimap, controls, background |
+| [`elkjs`](https://github.com/kieler/elkjs) | `^0.9` | Auto-layout engine (Eclipse Layout Kernel, WASM-free JS build) — computes node positions and orthogonal edge routes |
+
+Peer deps: `react` / `react-dom` (18 or 19). No Tailwind, no CSS framework, no icon package — the
+toolkit injects one self-contained stylesheet and ships its own line-icon set.
+
+```sh
+npm i @xyflow/react elkjs        # or pnpm add / yarn add
+```
+
+> **Why ELK and not React Flow's built-in layout?** React Flow does not lay out graphs — you give it
+> positioned nodes. ELK's `layered` algorithm (Sugiyama-style) produces clean left-to-right or
+> top-down tiers and, crucially, **orthogonal edge routes with bend points** that bend *around*
+> nodes instead of cutting through them. We consume those routes directly. Alternatives: `dagre`
+> (simpler, no port routing, edges can overlap nodes), `d3-force` (organic but non-deterministic —
+> bad for docs). ELK is the right pick for architecture diagrams.
+
+## How it fits together
+
+```
+DiagramSpec (your data)
+      │
+      ▼
+runElkLayout(spec)  ──►  ELK computes node x/y + edge waypoints
+      │
+      ▼
+React Flow  ──►  custom node components (themed) + custom orthogonal edge
+      │
+      ▼
+DiagramViewer  ──►  sidebar picker + header + canvas + legend
+```
+
+The bundled toolkit (`reference/src/`) is ~11 small files. Copy the whole `src/` tree into your
+project (e.g. `src/lib/diagrams/` or a local package), then write diagram data files and mount
+`<DiagramViewer diagrams={...} />` on a route.
+
+## Quick start (any React app)
+
+1. **Install deps**: `npm i @xyflow/react elkjs`.
+2. **Copy the toolkit**: copy `reference/src/` from this skill into your project (keep the folder
+   structure — `theme/`, `layout/`, `nodes/`, and the top-level files).
+3. **Write a diagram** as a typed `DiagramSpec` data file (see `reference/examples/`).
+4. **Register diagrams** in an array and mount the viewer on a **client-rendered** route:
+
+   ```tsx
+   import {DiagramViewer} from '@/lib/diagrams'
+   import {MY_DIAGRAMS} from '@/features/docs/diagrams'
+
+   export function DocsScreen() {
+     return (
+       <div style={{position: 'relative', width: '100%', height: 'calc(100dvh - 24px)'}}>
+         <DiagramViewer diagrams={MY_DIAGRAMS} title="My System" subtitle="Architecture" />
+       </div>
+     )
+   }
+   ```
+
+5. **Give the viewer a real height.** It fills its parent (`height: 100%`), so the wrapper must have
+   a concrete height (`100dvh`, a flex child, etc.) or the canvas collapses to 0px.
+
+## The data contract (`DiagramSpec`)
+
+This is the only thing authors (or an LLM) touch. Full types in `reference/src/types.ts`.
+
+```ts
+interface DiagramSpec {
+  id: string                 // stable key; used to remount the canvas on switch
+  title: string
+  description?: string       // caption in the header + picker
+  group?: string             // sidebar grouping label
+  layout?: {direction?: 'RIGHT' | 'DOWN'}  // default RIGHT (left-to-right)
+  nodes: DiagramNode[]
+  edges: DiagramEdge[]
+}
+
+interface DiagramNode {
+  id: string
+  kind: 'service' | 'datastore' | 'queue' | 'topic' | 'external' | 'process' | 'client' | 'boundary'
+  label: string
+  sublabel?: string          // secondary line (tech, table name, ARN suffix)
+  domain?: string            // color bucket — see DOMAIN_PALETTE
+  icon?: string              // icon key (see ICONS); falls back to a kind glyph
+  parent?: string            // id of a `boundary` node to nest inside
+  meta?: Record<string, string>  // up to 3 shown as chips on the card
+}
+
+interface DiagramEdge {
+  id: string
+  source: string             // node id
+  target: string             // node id
+  label?: string             // routed into the inter-layer gap
+  variant?: 'data' | 'request' | 'event' | 'async' | 'dependency'  // default 'data'
+  animated?: boolean         // override variant default
+}
+```
+
+**Authoring rules:**
+
+- `kind` picks the *shape/component*; `domain` picks the *color*. Keep them orthogonal — e.g. a
+  `service` node in the `event` domain renders the service card in amber.
+- Nest nodes in a `boundary` by setting `parent: '<boundary-id>'`. The boundary is sized by ELK from
+  its children — never give it a fixed size.
+- Edge `variant` carries meaning (see Edge variants below). Pick the one that matches the
+  relationship; the legend explains it to readers automatically.
+- Give every node a `sublabel` with the concrete tech/identifier — it's what makes the diagram
+  *recognizable* rather than generic boxes.
+
+## Rendering
+
+### Client-only is mandatory
+
+ELK and React Flow both need a real DOM (to measure and to render SVG). They **cannot run during
+SSR**. The toolkit gates rendering behind `ClientOnly` (a mount-effect flag); the server and first
+paint show a `Loading diagram…` fallback, then the client hydrates the canvas.
+
+Framework specifics:
+
+- **TanStack Start**: the bundled `ClientOnly` is enough — the route component renders normally and
+  the canvas defers itself.
+- **Next.js App Router**: add `'use client'` at the top of any file that imports the viewer/canvas
+  (they use hooks and browser APIs). Either keep `ClientOnly`, or import the viewer via
+  `next/dynamic` with `{ssr: false}` and you can drop `ClientOnly`. Doing both is harmless.
+- **Next.js Pages Router**: same — `dynamic(() => import('...'), {ssr: false})`.
+
+```tsx
+// Next.js App Router page
+'use client'
+import dynamic from 'next/dynamic'
+const DocsScreen = dynamic(() => import('@/features/docs/DocsScreen'), {ssr: false})
+export default function Page() { return <DocsScreen /> }
+```
+
+### Remount on switch (subtle but important)
+
+`DiagramViewer` renders `<DiagramCanvas key={active.id} spec={active} />`. The `key` forces a **full
+remount** when you switch diagrams. An in-place nodes/edges swap does *not* re-trigger React Flow's
+node measurement, which leaves edges unanchored (they silently fail to draw). A fresh mount fixes
+it. Keep the `key`.
+
+### Seed node sizes so edges have anchors
+
+When building React Flow nodes, set `width`/`height` **on the node object** (not only in `style`).
+React Flow seeds its `measured` dimensions from those and computes handle bounds immediately —
+without them, edges have no anchor points and don't render until a resize nudges measurement. The
+bundled `layout/elk.ts` already does this; preserve it if you refactor.
+
+## Positioning (ELK layout)
+
+All positioning lives in `reference/src/layout/elk.ts`. You normally never edit it — but understand
+the knobs.
+
+Key ELK options (on the root graph):
+
+```ts
+'elk.algorithm': 'layered',                              // tiered Sugiyama layout
+'elk.layered.spacing.nodeNodeBetweenLayers': '130',      // wide gaps so edge LABELS fit in them
+'elk.spacing.nodeNode': '64',
+'elk.edgeRouting': 'ORTHOGONAL',                         // L-shaped routes with bend points
+'elk.edgeLabels.placement': 'CENTER',                    // label sits in the inter-layer gap
+'elk.aspectRatio': '1.7',                                // bias away from thin sprawling bands
+'elk.hierarchyHandling': 'INCLUDE_CHILDREN',             // enables boundary nesting
+'elk.direction': 'RIGHT' | 'DOWN',                       // from spec.layout
+```
+
+Three things the layout pass does that are easy to get wrong if you reimplement:
+
+1. **Consume ELK's edge routes.** ELK returns `sections[].startPoint / bendPoints / endPoint`. We
+   render edges along *those* waypoints (custom `OrthogonalEdge`), not React Flow's handle-to-handle
+   smoothstep. This is what stops edges cutting across unrelated nodes or looping backward.
+2. **Translate boundary-local edge coordinates.** With `INCLUDE_CHILDREN`, ELK reports an edge's
+   coordinates relative to the **lowest common ancestor boundary** of its two endpoints, not the
+   root. An edge between two children of the same boundary comes back in *boundary-local* coords and
+   must be shifted by that boundary's absolute origin, or it renders detached. The layout pass walks
+   the tree to compute absolute positions and offsets each edge accordingly.
+3. **Nest containers via `parentId` + `extent: 'parent'`.** Children get `parentId` so React Flow
+   positions them relative to the boundary, and `extent: 'parent'` keeps them clipped inside.
+
+Fixed node sizes per kind live in `theme/tokens.ts` (`NODE_SIZE`) — e.g. `service` is 248×96.
+Boundaries are *not* fixed; ELK sizes them from their children plus padding.
+
+## Styling
+
+One self-contained stylesheet (`theme/stylesheet.ts`, the `RFD_STYLESHEET` string) is injected once
+by the viewer via `<style>`. No Tailwind needed. It is built around **CSS custom properties** so it
+themes cleanly and supports dark mode without a single dark-mode branch.
+
+### Theme via CSS variables
+
+The stylesheet reads host theme tokens with standalone fallbacks:
+
+```css
+--rfd-ink:    var(--pg-ink, #0f172a);     /* text */
+--rfd-card:   var(--pg-shell, #ffffff);   /* node background */
+--rfd-border: var(--pg-border, rgba(100,116,139,0.22));
+--rfd-edge:   var(--pg-subtle, #64748b);  /* default edge */
+```
+
+**Portability:** the `--pg-*` names are Photon Grove's design tokens (set by
+`@photon-grove/react-ui`'s ThemeProvider). In another app, either (a) define `--pg-ink`,
+`--pg-shell`, `--pg-border`, `--pg-subtle`, `--pg-hover`, `--pg-font-sans` on a wrapping element, or
+(b) rename the `var(--pg-*, …)` references in `stylesheet.ts` to your own token names. The hard-coded
+fallbacks mean it looks correct out of the box even with no tokens defined. Dark mode "just works"
+if your tokens flip — the layout uses `color-mix(...)` against `--rfd-ink`/`--rfd-card` rather than
+fixed light colors.
+
+### Node anatomy
+
+Each leaf node is: a 3px accent **bar**, an **icon chip** (32×32, accent-tinted), a **title**, an
+optional **sublabel**, and up to three **meta chips**. The per-node accent comes from `domain`:
+each node sets inline `--rfd-accent` / `--rfd-soft` from the palette, and the CSS derives the bar,
+icon chip, gradient header, hover ring, and border from that single accent via `color-mix`.
+
+### Domain palette (color coding)
+
+`theme/tokens.ts` → `DOMAIN_PALETTE` maps a domain to `{accent, soft}`. Built-in buckets:
+
+`web, client, api, auth, ingestion, planner, ai, data, queue, event, external, observability,
+domain`. Unknown domains fall back to neutral slate. Add or recolor buckets by editing this one map
+— pick accents that read on both light and dark surfaces, and a translucent `soft` (the icon-chip
+fill and gradient).
+
+### Edge variants
+
+`theme/tokens.ts` → `EDGE_STYLE` defines five semantic edge styles:
+
+| Variant | Look | Meaning |
+|---|---|---|
+| `data` | solid, muted | synchronous data flow (default) |
+| `request` | solid, accent | request/response call |
+| `event` | solid, amber, **animated** | emitted event / stream record |
+| `async` | dashed, amber, animated | async hand-off through a queue |
+| `dependency` | dotted, no arrowhead | soft dependency / reference |
+
+Edge labels render as an opaque bordered chip so they stay legible even when they land near another
+edge. Arrowheads use `MarkerType.ArrowClosed` (omitted for `dependency`).
+
+### Legend
+
+`Legend` auto-derives its contents from the active spec — it lists **only** the domains, node kinds,
+and edge variants actually present in that diagram, so each legend stays relevant. Nothing to
+maintain by hand.
+
+## Authoring a diagram set (recommended layout)
+
+```
+features/docs/
+  DocsScreen.tsx               # mounts <DiagramViewer diagrams={ALL} ... />
+  diagrams/
+    index.ts                   # export const ALL: DiagramSpec[] = [a, b, c, ...]
+    01-system-landscape.ts     # one DiagramSpec per file, numbered for order
+    02-...
+```
+
+- Order diagrams semantically: overview → architecture patterns → specific tiers.
+- Use `group` to bucket them in the sidebar (`'Architecture'`, `'Web'`, `'Data'`).
+- Keep each spec to ~10–25 nodes. If it's bigger, split it — a diagram nobody can read at a glance
+  has failed its job.
+- See `reference/examples/cqrs-event-sourcing.ts` for a complete, idiomatic spec (boundaries,
+  nesting, all five edge variants, meaningful sublabels).
+
+## Build checklist
+
+When standing this up in a project:
+
+1. `npm i @xyflow/react elkjs` (confirm React 18/19 present).
+2. Copy `reference/src/` into the project; fix the import of React Flow's stylesheet
+   (`@xyflow/react/dist/style.css`) is already done inside `DiagramCanvas.tsx`.
+3. Decide theming: define `--pg-*` tokens on a wrapper, or rename to your tokens in
+   `stylesheet.ts`. Confirm light/dark both read well.
+4. Write 1 diagram, mount `<DiagramViewer>` on a **client** route with a real height.
+5. Verify: canvas renders, you can pan/zoom, edges route around nodes, labels sit in gaps, the
+   minimap colors match domains, switching diagrams redraws cleanly.
+6. Add the rest of the diagrams as data files; register in the index array.
+7. Update the app's docs/README index to point at the new `/docs` route.
+
+## Pitfalls
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Blank / 0-height canvas | Viewer parent has no height | Give the wrapper a concrete height (`100dvh`, flex child) |
+| `window is not defined` / hydration error | Rendered during SSR | Keep `ClientOnly`, or `next/dynamic({ssr:false})` in Next.js |
+| Edges don't draw | Nodes lack measured size | Set `width`/`height` on the node object, not just `style` (bundled layout does this) |
+| Edges cut through nodes | Not consuming ELK routes | Use the custom `OrthogonalEdge` + route data from `runElkLayout` |
+| Boundary-internal edge floats away from its nodes | Boundary-local coords not translated | Offset edge waypoints by the lowest-common-ancestor boundary origin (bundled layout does this) |
+| Stale/unanchored edges after switching diagrams | Canvas reused, not remounted | Key the canvas by `spec.id` |
+| Colors look wrong in dark mode | Host tokens missing/not flipping | Define `--pg-*` (or your) tokens that flip with theme; fallbacks are light-only |
+| Diagram sprawls into a thin band | Too many sibling nodes in one layer | Group with boundaries; tune `elk.aspectRatio` / split the diagram |
+
+## Reference files
+
+`reference/src/` is a verbatim, framework-agnostic copy of the toolkit — copy it wholesale:
+
+- `index.ts` — public exports
+- `types.ts` — the `DiagramSpec` contract (the stable public interface)
+- `layout/elk.ts` — ELK layout + route translation → React Flow nodes/edges
+- `nodes/nodes.tsx` — themed leaf + boundary node components
+- `nodes/edges.tsx` — custom orthogonal edge that follows ELK waypoints
+- `theme/tokens.ts` — domain palette, node sizes, edge styles, labels
+- `theme/stylesheet.ts` — the single injected stylesheet (CSS-var themed)
+- `theme/icons.tsx` — self-contained line-icon set
+- `ClientOnly.tsx` — SSR boundary
+- `DiagramCanvas.tsx` — single-diagram canvas (ELK → React Flow)
+- `DiagramViewer.tsx` — the full sidebar + canvas + legend experience
+- `Legend.tsx` — auto-derived legend
+- `examples/cqrs-event-sourcing.ts` — a complete example spec to copy from
+
+> Source of truth in the Photon Grove monorepo: `packages/react-flow-diagrams`. If you're working
+> *inside* `photon-grove/apps`, import `@photon-grove/react-flow-diagrams` directly instead of
+> copying. The `reference/` copy exists so this skill works in any other repo.
+</content>
+</invoke>

--- a/skills/architecture-diagrams/SKILL.md
+++ b/skills/architecture-diagrams/SKILL.md
@@ -65,7 +65,7 @@ React Flow  ──►  custom node components (themed) + custom orthogonal edge
 DiagramViewer  ──►  sidebar picker + header + canvas + legend
 ```
 
-The bundled toolkit (`reference/src/`) is ~11 small files. Copy the whole `src/` tree into your
+The bundled toolkit (`reference/src/`) is about a dozen small files. Copy the whole `src/` tree into your
 project (e.g. `src/lib/diagrams/` or a local package), then write diagram data files and mount
 `<DiagramViewer diagrams={...} />` on a route.
 
@@ -231,9 +231,9 @@ The stylesheet reads host theme tokens with standalone fallbacks:
 ```
 
 **Portability:** the `--app-*` names are placeholder host tokens you map to whatever design system
-the app already uses. Either (a) define `--app-ink`, `--app-surface`, `--app-border`, `--app-subtle`,
-`--app-hover`, `--app-font-sans` (and optionally `--app-accent`) on a wrapping element, or (b) rename
-the `var(--app-*, …)` references in `stylesheet.ts` to your own token names. The hard-coded fallbacks
+the app already uses. Either (a) define `--app-ink`, `--app-muted`, `--app-surface`, `--app-border`,
+`--app-subtle`, `--app-hover`, `--app-font-sans` (and optionally `--app-accent`) on a wrapping
+element, or (b) rename the `var(--app-*, …)` references in `stylesheet.ts` to your own token names. The hard-coded fallbacks
 mean it looks correct out of the box even with no tokens defined. Dark mode "just works" if your
 tokens flip — the layout uses `color-mix(...)` against `--rfd-ink`/`--rfd-card` rather than fixed
 light colors.
@@ -298,8 +298,9 @@ features/docs/
 When standing this up in a project:
 
 1. `npm i @xyflow/react elkjs` (confirm React 18/19 present).
-2. Copy `reference/src/` into the project; fix the import of React Flow's stylesheet
-   (`@xyflow/react/dist/style.css`) is already done inside `DiagramCanvas.tsx`.
+2. Copy `reference/src/` into the project. The React Flow stylesheet import
+   (`@xyflow/react/dist/style.css`) is already handled inside `DiagramCanvas.tsx`, so there's
+   nothing extra to wire up.
 3. Decide theming: define `--app-*` tokens on a wrapper, or rename to your tokens in
    `stylesheet.ts`. Confirm light/dark both read well.
 4. Write 1 diagram, mount `<DiagramViewer>` on a **client** route with a real height.

--- a/skills/architecture-diagrams/reference/README.md
+++ b/skills/architecture-diagrams/reference/README.md
@@ -54,8 +54,8 @@ client'` / `dynamic({ssr:false})` notes) and give the wrapper a real height.
 ## Theming
 
 The stylesheet reads `--app-*` host tokens with light-mode fallbacks. To theme: define `--app-ink`,
-`--app-surface`, `--app-border`, `--app-subtle`, `--app-hover`, `--app-font-sans` (and optionally
-`--app-accent`) on a wrapping element, or rename the `var(--app-*, …)` references in
+`--app-muted`, `--app-surface`, `--app-border`, `--app-subtle`, `--app-hover`, `--app-font-sans`
+(and optionally `--app-accent`) on a wrapping element, or rename the `var(--app-*, …)` references in
 `theme/stylesheet.ts` to whatever design tokens you already use. Dark mode works automatically if
 those tokens flip.
 </content>

--- a/skills/architecture-diagrams/reference/README.md
+++ b/skills/architecture-diagrams/reference/README.md
@@ -1,0 +1,63 @@
+# reference/ — copy-paste toolkit
+
+A verbatim, framework-agnostic copy of the React Flow + ELK diagram toolkit behind the Homunculus
+`/docs` page. Drop `src/` into any React 18/19 app and you have the whole system.
+
+## Install
+
+```sh
+npm i @xyflow/react elkjs      # pnpm add / yarn add also fine
+```
+
+## Copy
+
+Copy `src/` into your project, e.g. `src/lib/diagrams/`. Keep the folder structure:
+
+```
+src/
+  index.ts            # public exports — import everything from here
+  types.ts            # DiagramSpec contract (the data you author)
+  layout/elk.ts       # ELK layout + edge-route translation
+  nodes/nodes.tsx     # themed leaf + boundary node components
+  nodes/edges.tsx     # custom orthogonal edge (follows ELK waypoints)
+  theme/tokens.ts     # domain palette, node sizes, edge styles
+  theme/stylesheet.ts # the single injected stylesheet (CSS-var themed)
+  theme/icons.tsx     # self-contained line-icon set
+  ClientOnly.tsx      # SSR boundary
+  DiagramCanvas.tsx   # one diagram → ELK → React Flow
+  DiagramViewer.tsx   # sidebar + canvas + legend (the full experience)
+  Legend.tsx          # auto-derived legend
+examples/
+  cqrs-event-sourcing.ts   # a complete spec to copy from
+```
+
+## Use
+
+```tsx
+import {DiagramViewer, type DiagramSpec} from '@/lib/diagrams'
+import {cqrsEventSourcing} from './diagrams/cqrs-event-sourcing'
+
+const DIAGRAMS: DiagramSpec[] = [cqrsEventSourcing /* , ... */]
+
+export function DocsScreen() {
+  return (
+    <div style={{position: 'relative', width: '100%', height: 'calc(100dvh - 24px)'}}>
+      <DiagramViewer diagrams={DIAGRAMS} title="My System" subtitle="Architecture" />
+    </div>
+  )
+}
+```
+
+Mount `DocsScreen` on a **client-rendered** route (see SKILL.md → Rendering for Next.js `'use
+client'` / `dynamic({ssr:false})` notes) and give the wrapper a real height.
+
+## Theming
+
+The stylesheet reads `--pg-*` design tokens with light-mode fallbacks. To theme: define `--pg-ink`,
+`--pg-shell`, `--pg-border`, `--pg-subtle`, `--pg-hover`, `--pg-font-sans` on a wrapping element, or
+rename the `var(--pg-*, …)` references in `theme/stylesheet.ts` to your own tokens. Dark mode works
+automatically if those tokens flip.
+
+> If you're inside the `photon-grove/apps` monorepo, skip the copy and import
+> `@photon-grove/react-flow-diagrams` directly — this folder is the source of truth's portable twin.
+</content>

--- a/skills/architecture-diagrams/reference/README.md
+++ b/skills/architecture-diagrams/reference/README.md
@@ -1,7 +1,7 @@
 # reference/ — copy-paste toolkit
 
-A verbatim, framework-agnostic copy of the React Flow + ELK diagram toolkit behind the Homunculus
-`/docs` page. Drop `src/` into any React 18/19 app and you have the whole system.
+A self-contained, framework-agnostic React Flow + ELK diagram toolkit. Drop `src/` into any React
+18/19 app and you have the whole system.
 
 ## Install
 
@@ -53,11 +53,9 @@ client'` / `dynamic({ssr:false})` notes) and give the wrapper a real height.
 
 ## Theming
 
-The stylesheet reads `--pg-*` design tokens with light-mode fallbacks. To theme: define `--pg-ink`,
-`--pg-shell`, `--pg-border`, `--pg-subtle`, `--pg-hover`, `--pg-font-sans` on a wrapping element, or
-rename the `var(--pg-*, …)` references in `theme/stylesheet.ts` to your own tokens. Dark mode works
-automatically if those tokens flip.
-
-> If you're inside the `photon-grove/apps` monorepo, skip the copy and import
-> `@photon-grove/react-flow-diagrams` directly — this folder is the source of truth's portable twin.
+The stylesheet reads `--app-*` host tokens with light-mode fallbacks. To theme: define `--app-ink`,
+`--app-surface`, `--app-border`, `--app-subtle`, `--app-hover`, `--app-font-sans` (and optionally
+`--app-accent`) on a wrapping element, or rename the `var(--app-*, …)` references in
+`theme/stylesheet.ts` to whatever design tokens you already use. Dark mode works automatically if
+those tokens flip.
 </content>

--- a/skills/architecture-diagrams/reference/README.md
+++ b/skills/architecture-diagrams/reference/README.md
@@ -51,6 +51,23 @@ export function DocsScreen() {
 Mount `DocsScreen` on a **client-rendered** route (see SKILL.md → Rendering for Next.js `'use
 client'` / `dynamic({ssr:false})` notes) and give the wrapper a real height.
 
+## Styles
+
+React Flow needs its base stylesheet. Import it **once, at your app's global entry** — the toolkit
+intentionally does *not* import it inside a component, because a global CSS import inside a component
+breaks Next.js builds:
+
+```ts
+import '@xyflow/react/dist/style.css'
+```
+
+- **Next.js App Router** → `app/layout.tsx`
+- **Next.js Pages Router** → `pages/_app.tsx`
+- **TanStack Start / Vite / Remix** → the root route/layout or app entry (e.g. `main.tsx`)
+
+The toolkit's own visual styles (`RFD_STYLESHEET`) are injected automatically by `DiagramViewer`;
+only React Flow's base CSS is your responsibility.
+
 ## Theming
 
 The stylesheet reads `--app-*` host tokens with light-mode fallbacks. To theme: define `--app-ink`,
@@ -58,4 +75,3 @@ The stylesheet reads `--app-*` host tokens with light-mode fallbacks. To theme: 
 (and optionally `--app-accent`) on a wrapping element, or rename the `var(--app-*, …)` references in
 `theme/stylesheet.ts` to whatever design tokens you already use. Dark mode works automatically if
 those tokens flip.
-</content>

--- a/skills/architecture-diagrams/reference/examples/cqrs-event-sourcing.ts
+++ b/skills/architecture-diagrams/reference/examples/cqrs-event-sourcing.ts
@@ -1,0 +1,152 @@
+// Example DiagramSpec. In a real app you'd import the type from wherever you
+// dropped the toolkit, e.g. `import type {DiagramSpec} from '@/lib/diagrams'`.
+// Here it points at the bundled reference copy.
+import type {DiagramSpec} from '../src/types'
+
+/**
+ * The CQRS split: event-sourced write model on the left, denormalized read
+ * model on the right, with inline projection and a replay path.
+ *
+ * Note how the spec carries *meaning*, not coordinates:
+ *  - `kind` picks the component/shape, `domain` picks the color (kept orthogonal).
+ *  - `parent` nests nodes inside a `boundary`; ELK sizes the boundary.
+ *  - every node has a concrete `sublabel` so the diagram is recognizable.
+ *  - edge `variant` encodes the relationship and drives the legend.
+ */
+export const cqrsEventSourcing: DiagramSpec = {
+  id: 'cqrs-event-sourcing',
+  title: 'CQRS & event sourcing',
+  group: 'Architecture',
+  description:
+    'Commands mutate event-sourced aggregates; events land in the event-log, fan out via a topic, and materialize inline into the read model that the API queries by exact key. A separate indexer rebuilds a search artifact from the same events.',
+  layout: {direction: 'RIGHT'},
+  nodes: [
+    {id: 'write', kind: 'boundary', label: 'Write model', domain: 'api'},
+    {
+      id: 'cmd',
+      kind: 'process',
+      label: 'Command',
+      sublabel: 'CommandService.Execute',
+      domain: 'api',
+      icon: 'process',
+      parent: 'write',
+    },
+    {
+      id: 'agg',
+      kind: 'service',
+      label: 'Aggregate',
+      sublabel: 'apply + emit',
+      domain: 'domain',
+      icon: 'gear',
+      parent: 'write',
+    },
+    {
+      id: 'eventlog',
+      kind: 'datastore',
+      label: 'event-log',
+      sublabel: 'pk=stream · sk=seq',
+      domain: 'data',
+      icon: 'datastore',
+      parent: 'write',
+    },
+
+    {id: 'stream', kind: 'process', label: 'Change Stream', domain: 'event', icon: 'event'},
+    {
+      id: 'publisher',
+      kind: 'service',
+      label: 'publisher',
+      sublabel: 'partial-batch + DLQ',
+      domain: 'event',
+      icon: 'topic',
+    },
+    {
+      id: 'topic',
+      kind: 'topic',
+      label: 'events',
+      sublabel: 'pub/sub fan-out',
+      domain: 'event',
+      icon: 'topic',
+    },
+
+    {id: 'read', kind: 'boundary', label: 'Read model', domain: 'data'},
+    {
+      id: 'project',
+      kind: 'process',
+      label: 'Projectors',
+      sublabel: 'inline materialize',
+      domain: 'data',
+      icon: 'process',
+      parent: 'read',
+    },
+    {
+      id: 'views',
+      kind: 'datastore',
+      label: 'entity-views',
+      sublabel: 'PK per access pattern',
+      domain: 'data',
+      icon: 'datastore',
+      parent: 'read',
+    },
+    {
+      id: 'searchindexer',
+      kind: 'service',
+      label: 'search-indexer',
+      sublabel: 'queue-triggered rebuild',
+      domain: 'ingestion',
+      icon: 'lambda',
+    },
+    {
+      id: 'searchidx',
+      kind: 'datastore',
+      label: 'search-index',
+      sublabel: 'FTS artifact',
+      domain: 'data',
+      icon: 'search',
+    },
+
+    {
+      id: 'rebuild',
+      kind: 'process',
+      label: 'rebuild-projections',
+      sublabel: 'CLI replay',
+      domain: 'ingestion',
+      icon: 'gear',
+    },
+    {
+      id: 'queryapi',
+      kind: 'service',
+      label: 'Query API',
+      sublabel: 'ViewQueryService',
+      domain: 'api',
+      icon: 'lambda',
+    },
+  ],
+  edges: [
+    {id: 'cmd-agg', source: 'cmd', target: 'agg', variant: 'data'},
+    {id: 'agg-log', source: 'agg', target: 'eventlog', variant: 'event', label: 'append events'},
+    {id: 'agg-project', source: 'agg', target: 'project', variant: 'data', label: 'inline'},
+    {id: 'project-views', source: 'project', target: 'views', variant: 'data'},
+    {id: 'log-stream', source: 'eventlog', target: 'stream', variant: 'event'},
+    {id: 'stream-pub', source: 'stream', target: 'publisher', variant: 'event'},
+    {id: 'pub-topic', source: 'publisher', target: 'topic', variant: 'event'},
+    {
+      id: 'topic-indexer',
+      source: 'topic',
+      target: 'searchindexer',
+      variant: 'async',
+      label: 'filtered queue sub',
+    },
+    {
+      id: 'indexer-search',
+      source: 'searchindexer',
+      target: 'searchidx',
+      variant: 'data',
+      label: 'rebuild',
+    },
+    {id: 'search-query', source: 'searchidx', target: 'queryapi', variant: 'data', label: 'FTS read'},
+    {id: 'log-rebuild', source: 'eventlog', target: 'rebuild', variant: 'dependency', label: 'replay'},
+    {id: 'rebuild-views', source: 'rebuild', target: 'views', variant: 'data'},
+    {id: 'views-query', source: 'views', target: 'queryapi', variant: 'data', label: 'PK query'},
+  ],
+}
+</content>

--- a/skills/architecture-diagrams/reference/examples/cqrs-event-sourcing.ts
+++ b/skills/architecture-diagrams/reference/examples/cqrs-event-sourcing.ts
@@ -1,32 +1,34 @@
-// Example DiagramSpec. In a real app you'd import the type from wherever you
-// dropped the toolkit, e.g. `import type {DiagramSpec} from '@/lib/diagrams'`.
+// Example DiagramSpec — a hypothetical CQRS / event-sourcing system, included
+// only to show the data shape. In a real app you'd import the type from wherever
+// you dropped the toolkit, e.g. `import type {DiagramSpec} from '@/lib/diagrams'`.
 // Here it points at the bundled reference copy.
 import type {DiagramSpec} from '../src/types'
 
 /**
- * The CQRS split: event-sourced write model on the left, denormalized read
- * model on the right, with inline projection and a replay path.
+ * A made-up CQRS split: an event-sourced write model on the left, a denormalized
+ * read model on the right, with inline projection and a replay path. The point
+ * is the *shape*, not the system — swap in your own nodes and edges.
  *
  * Note how the spec carries *meaning*, not coordinates:
  *  - `kind` picks the component/shape, `domain` picks the color (kept orthogonal).
  *  - `parent` nests nodes inside a `boundary`; ELK sizes the boundary.
- *  - every node has a concrete `sublabel` so the diagram is recognizable.
+ *  - every node has a short `sublabel` so the card is self-explaining.
  *  - edge `variant` encodes the relationship and drives the legend.
  */
 export const cqrsEventSourcing: DiagramSpec = {
   id: 'cqrs-event-sourcing',
   title: 'CQRS & event sourcing',
-  group: 'Architecture',
+  group: 'Patterns',
   description:
-    'Commands mutate event-sourced aggregates; events land in the event-log, fan out via a topic, and materialize inline into the read model that the API queries by exact key. A separate indexer rebuilds a search artifact from the same events.',
+    'A command mutates an event-sourced aggregate; events are appended to a log, fan out over a topic, and are projected into a read model the query side serves. A separate indexer rebuilds a search index from the same events, and a replay job can rebuild the read model from the log.',
   layout: {direction: 'RIGHT'},
   nodes: [
     {id: 'write', kind: 'boundary', label: 'Write model', domain: 'api'},
     {
       id: 'cmd',
       kind: 'process',
-      label: 'Command',
-      sublabel: 'CommandService.Execute',
+      label: 'Command handler',
+      sublabel: 'validates + executes',
       domain: 'api',
       icon: 'process',
       parent: 'write',
@@ -35,7 +37,7 @@ export const cqrsEventSourcing: DiagramSpec = {
       id: 'agg',
       kind: 'service',
       label: 'Aggregate',
-      sublabel: 'apply + emit',
+      sublabel: 'applies + emits events',
       domain: 'domain',
       icon: 'gear',
       parent: 'write',
@@ -43,26 +45,26 @@ export const cqrsEventSourcing: DiagramSpec = {
     {
       id: 'eventlog',
       kind: 'datastore',
-      label: 'event-log',
-      sublabel: 'pk=stream · sk=seq',
+      label: 'Event log',
+      sublabel: 'append-only',
       domain: 'data',
       icon: 'datastore',
       parent: 'write',
     },
 
-    {id: 'stream', kind: 'process', label: 'Change Stream', domain: 'event', icon: 'event'},
+    {id: 'stream', kind: 'process', label: 'Change stream', domain: 'event', icon: 'event'},
     {
       id: 'publisher',
       kind: 'service',
-      label: 'publisher',
-      sublabel: 'partial-batch + DLQ',
+      label: 'Event publisher',
+      sublabel: 'batched + retry',
       domain: 'event',
       icon: 'topic',
     },
     {
       id: 'topic',
       kind: 'topic',
-      label: 'events',
+      label: 'Events',
       sublabel: 'pub/sub fan-out',
       domain: 'event',
       icon: 'topic',
@@ -72,8 +74,8 @@ export const cqrsEventSourcing: DiagramSpec = {
     {
       id: 'project',
       kind: 'process',
-      label: 'Projectors',
-      sublabel: 'inline materialize',
+      label: 'Projector',
+      sublabel: 'builds read views',
       domain: 'data',
       icon: 'process',
       parent: 'read',
@@ -81,34 +83,34 @@ export const cqrsEventSourcing: DiagramSpec = {
     {
       id: 'views',
       kind: 'datastore',
-      label: 'entity-views',
-      sublabel: 'PK per access pattern',
+      label: 'Read views',
+      sublabel: 'query-optimized',
       domain: 'data',
       icon: 'datastore',
       parent: 'read',
     },
     {
-      id: 'searchindexer',
+      id: 'indexer',
       kind: 'service',
-      label: 'search-indexer',
-      sublabel: 'queue-triggered rebuild',
+      label: 'Search indexer',
+      sublabel: 'rebuilds index',
       domain: 'ingestion',
-      icon: 'lambda',
+      icon: 'gear',
     },
     {
       id: 'searchidx',
       kind: 'datastore',
-      label: 'search-index',
-      sublabel: 'FTS artifact',
+      label: 'Search index',
+      sublabel: 'full-text',
       domain: 'data',
       icon: 'search',
     },
 
     {
-      id: 'rebuild',
+      id: 'replay',
       kind: 'process',
-      label: 'rebuild-projections',
-      sublabel: 'CLI replay',
+      label: 'Replay job',
+      sublabel: 'rebuild from log',
       domain: 'ingestion',
       icon: 'gear',
     },
@@ -116,9 +118,9 @@ export const cqrsEventSourcing: DiagramSpec = {
       id: 'queryapi',
       kind: 'service',
       label: 'Query API',
-      sublabel: 'ViewQueryService',
+      sublabel: 'serves read side',
       domain: 'api',
-      icon: 'lambda',
+      icon: 'service',
     },
   ],
   edges: [
@@ -132,21 +134,21 @@ export const cqrsEventSourcing: DiagramSpec = {
     {
       id: 'topic-indexer',
       source: 'topic',
-      target: 'searchindexer',
+      target: 'indexer',
       variant: 'async',
-      label: 'filtered queue sub',
+      label: 'subscribe',
     },
+    {id: 'indexer-search', source: 'indexer', target: 'searchidx', variant: 'data', label: 'rebuild'},
     {
-      id: 'indexer-search',
-      source: 'searchindexer',
-      target: 'searchidx',
+      id: 'search-query',
+      source: 'searchidx',
+      target: 'queryapi',
       variant: 'data',
-      label: 'rebuild',
+      label: 'full-text read',
     },
-    {id: 'search-query', source: 'searchidx', target: 'queryapi', variant: 'data', label: 'FTS read'},
-    {id: 'log-rebuild', source: 'eventlog', target: 'rebuild', variant: 'dependency', label: 'replay'},
-    {id: 'rebuild-views', source: 'rebuild', target: 'views', variant: 'data'},
-    {id: 'views-query', source: 'views', target: 'queryapi', variant: 'data', label: 'PK query'},
+    {id: 'log-replay', source: 'eventlog', target: 'replay', variant: 'dependency', label: 'replay'},
+    {id: 'replay-views', source: 'replay', target: 'views', variant: 'data'},
+    {id: 'views-query', source: 'views', target: 'queryapi', variant: 'data', label: 'read'},
   ],
 }
 </content>

--- a/skills/architecture-diagrams/reference/examples/cqrs-event-sourcing.ts
+++ b/skills/architecture-diagrams/reference/examples/cqrs-event-sourcing.ts
@@ -151,4 +151,3 @@ export const cqrsEventSourcing: DiagramSpec = {
     {id: 'views-query', source: 'views', target: 'queryapi', variant: 'data', label: 'read'},
   ],
 }
-</content>

--- a/skills/architecture-diagrams/reference/src/ClientOnly.tsx
+++ b/skills/architecture-diagrams/reference/src/ClientOnly.tsx
@@ -19,4 +19,3 @@ export function ClientOnly({
 
   return mounted ? children : fallback
 }
-</content>

--- a/skills/architecture-diagrams/reference/src/ClientOnly.tsx
+++ b/skills/architecture-diagrams/reference/src/ClientOnly.tsx
@@ -1,0 +1,22 @@
+import {useEffect, useState, type ReactNode} from 'react'
+
+/**
+ * Defers rendering of its children until after mount. React Flow and ELK need
+ * a real DOM, so the interactive canvas must not run during SSR. The server
+ * (and the first client paint) shows `fallback` instead.
+ */
+export function ClientOnly({
+  children,
+  fallback = null,
+}: {
+  children: ReactNode
+  fallback?: ReactNode
+}): ReactNode {
+  const [mounted, setMounted] = useState(false)
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  return mounted ? children : fallback
+}
+</content>

--- a/skills/architecture-diagrams/reference/src/DiagramCanvas.tsx
+++ b/skills/architecture-diagrams/reference/src/DiagramCanvas.tsx
@@ -9,7 +9,11 @@ import {
 } from '@xyflow/react'
 import {useEffect, useState, type ReactElement} from 'react'
 
-import '@xyflow/react/dist/style.css'
+// NOTE: React Flow's base stylesheet must be imported once, by the consuming
+// app, at its global entry — NOT here. A global CSS import inside a component
+// breaks Next.js builds (App Router only allows global CSS in app/layout.*;
+// Pages Router only in pages/_app.*). See the toolkit README "Styles" section:
+//   import '@xyflow/react/dist/style.css'
 
 import {runElkLayout, type LaidOutGraph} from './layout/elk'
 import {edgeTypes} from './nodes/edges'
@@ -81,4 +85,3 @@ export function DiagramCanvas({spec}: {spec: DiagramSpec}): ReactElement {
     </ReactFlowProvider>
   )
 }
-</content>

--- a/skills/architecture-diagrams/reference/src/DiagramCanvas.tsx
+++ b/skills/architecture-diagrams/reference/src/DiagramCanvas.tsx
@@ -1,0 +1,84 @@
+import {
+  Background,
+  BackgroundVariant,
+  Controls,
+  MiniMap,
+  ReactFlow,
+  ReactFlowProvider,
+  type Node,
+} from '@xyflow/react'
+import {useEffect, useState, type ReactElement} from 'react'
+
+import '@xyflow/react/dist/style.css'
+
+import {runElkLayout, type LaidOutGraph} from './layout/elk'
+import {edgeTypes} from './nodes/edges'
+import {nodeTypes} from './nodes/nodes'
+import {domainColor} from './theme/tokens'
+import type {DiagramNodeData, DiagramSpec} from './types'
+
+function miniMapColor(node: Node): string {
+  const data = node.data as DiagramNodeData | undefined
+  return domainColor(data?.node?.domain).accent
+}
+
+/**
+ * Renders a single laid-out diagram. Must run on the client only — wrap in
+ * {@link ClientOnly} (the DiagramViewer already does). Assumes the toolkit
+ * stylesheet is present (DiagramViewer injects it).
+ */
+export function DiagramCanvas({spec}: {spec: DiagramSpec}): ReactElement {
+  const [graph, setGraph] = useState<LaidOutGraph | null>(null)
+
+  useEffect(() => {
+    let active = true
+    setGraph(null)
+    runElkLayout(spec)
+      .then((result) => {
+        if (active) setGraph(result)
+      })
+      .catch(() => {
+        if (active) setGraph({nodes: [], edges: []})
+      })
+    return () => {
+      active = false
+    }
+  }, [spec])
+
+  if (!graph) {
+    return <div className="rfd-canvas__loading">Laying out diagram…</div>
+  }
+
+  return (
+    <ReactFlowProvider>
+      <ReactFlow
+        nodes={graph.nodes}
+        edges={graph.edges}
+        nodeTypes={nodeTypes}
+        edgeTypes={edgeTypes}
+        fitView
+        fitViewOptions={{padding: 0.08}}
+        minZoom={0.12}
+        maxZoom={1.8}
+        nodesConnectable={false}
+        proOptions={{hideAttribution: false}}
+      >
+        <Background
+          variant={BackgroundVariant.Dots}
+          gap={22}
+          size={1.1}
+          color="var(--rfd-edge-muted)"
+        />
+        <MiniMap
+          pannable
+          zoomable
+          nodeColor={miniMapColor}
+          nodeStrokeWidth={2}
+          maskColor="rgba(15,23,42,0.08)"
+        />
+        <Controls showInteractive={false} />
+      </ReactFlow>
+    </ReactFlowProvider>
+  )
+}
+</content>

--- a/skills/architecture-diagrams/reference/src/DiagramViewer.tsx
+++ b/skills/architecture-diagrams/reference/src/DiagramViewer.tsx
@@ -1,0 +1,111 @@
+import {useMemo, useState, type ReactElement} from 'react'
+
+import {ClientOnly} from './ClientOnly'
+import {DiagramCanvas} from './DiagramCanvas'
+import {Legend} from './Legend'
+import {RFD_STYLESHEET} from './theme/stylesheet'
+import type {DiagramSpec} from './types'
+
+const UNGROUPED = '__ungrouped__'
+
+interface DiagramGroup {
+  group: string
+  diagrams: DiagramSpec[]
+}
+
+function groupDiagrams(diagrams: DiagramSpec[]): DiagramGroup[] {
+  const order: string[] = []
+  const map = new Map<string, DiagramSpec[]>()
+  for (const diagram of diagrams) {
+    const key = diagram.group ?? UNGROUPED
+    if (!map.has(key)) {
+      map.set(key, [])
+      order.push(key)
+    }
+    map.get(key)?.push(diagram)
+  }
+  return order.map((group) => ({group, diagrams: map.get(group) ?? []}))
+}
+
+/**
+ * The full `/docs`-style experience: a sidebar picker plus the selected
+ * diagram canvas and its legend. Supply `diagrams`; everything else (layout,
+ * styling, theming) is handled by the toolkit.
+ */
+export function DiagramViewer({
+  diagrams,
+  title = 'Architecture',
+  subtitle,
+}: {
+  diagrams: DiagramSpec[]
+  title?: string
+  subtitle?: string
+}): ReactElement {
+  const [activeId, setActiveId] = useState(diagrams[0]?.id ?? '')
+  const active = useMemo(
+    () => diagrams.find((diagram) => diagram.id === activeId) ?? diagrams[0],
+    [diagrams, activeId]
+  )
+  const groups = useMemo(() => groupDiagrams(diagrams), [diagrams])
+
+  return (
+    <div className="rfd-root rfd-viewer">
+      <style dangerouslySetInnerHTML={{__html: RFD_STYLESHEET}} />
+      <aside className="rfd-viewer__nav">
+        <div className="rfd-viewer__brand">
+          <span className="rfd-viewer__brand-title">{title}</span>
+          {subtitle ? <span className="rfd-viewer__brand-sub">{subtitle}</span> : null}
+        </div>
+        {groups.map((group) => (
+          <div key={group.group} className="rfd-viewer__group">
+            {group.group !== UNGROUPED ? (
+              <span className="rfd-viewer__group-title">{group.group}</span>
+            ) : null}
+            {group.diagrams.map((diagram, index) => (
+              <button
+                key={diagram.id}
+                type="button"
+                className={
+                  'rfd-viewer__item' +
+                  (active?.id === diagram.id ? ' rfd-viewer__item--active' : '')
+                }
+                onClick={() => setActiveId(diagram.id)}
+              >
+                <span className="rfd-viewer__item-index">{index + 1}</span>
+                <span className="rfd-viewer__item-body">
+                  <span className="rfd-viewer__item-title">{diagram.title}</span>
+                  {diagram.description ? (
+                    <span className="rfd-viewer__item-desc">{diagram.description}</span>
+                  ) : null}
+                </span>
+              </button>
+            ))}
+          </div>
+        ))}
+      </aside>
+
+      <main className="rfd-viewer__main">
+        {active ? (
+          <>
+            <header className="rfd-viewer__header">
+              <h2 className="rfd-viewer__title">{active.title}</h2>
+              {active.description ? <p className="rfd-viewer__desc">{active.description}</p> : null}
+            </header>
+            <div className="rfd-viewer__canvas">
+              <ClientOnly fallback={<div className="rfd-canvas__loading">Loading diagram…</div>}>
+                {/* Key by id so switching diagrams fully remounts React Flow:
+                    an in-place nodes/edges swap doesn't re-trigger node
+                    measurement, leaving edges unanchored. A fresh mount does. */}
+                <DiagramCanvas key={active.id} spec={active} />
+              </ClientOnly>
+            </div>
+            <Legend spec={active} />
+          </>
+        ) : (
+          <div className="rfd-canvas__loading">No diagrams to show.</div>
+        )}
+      </main>
+    </div>
+  )
+}
+</content>

--- a/skills/architecture-diagrams/reference/src/DiagramViewer.tsx
+++ b/skills/architecture-diagrams/reference/src/DiagramViewer.tsx
@@ -108,4 +108,3 @@ export function DiagramViewer({
     </div>
   )
 }
-</content>

--- a/skills/architecture-diagrams/reference/src/Legend.tsx
+++ b/skills/architecture-diagrams/reference/src/Legend.tsx
@@ -1,0 +1,100 @@
+import type {ReactElement} from 'react'
+
+import {DiagramIcon} from './theme/icons'
+import {DOMAIN_PALETTE, EDGE_STYLE, EDGE_VARIANT_LABEL, KIND_LABEL} from './theme/tokens'
+import type {DiagramSpec, EdgeVariant, NodeKind} from './types'
+
+const DOMAIN_TITLES: Record<string, string> = {
+  web: 'Web tier',
+  client: 'Client',
+  api: 'API',
+  auth: 'Auth / IdP',
+  ingestion: 'Ingestion',
+  planner: 'Planner',
+  ai: 'AI / Bedrock',
+  data: 'Data store',
+  queue: 'Queue',
+  event: 'Events',
+  external: 'External',
+  observability: 'Observability',
+  domain: 'Domain model',
+}
+
+/**
+ * A compact, self-explaining key. By default it only lists the node kinds,
+ * domains, and edge variants actually present in `spec`, so each diagram's
+ * legend stays relevant.
+ */
+export function Legend({spec}: {spec?: DiagramSpec}): ReactElement {
+  const kinds = new Set<NodeKind>()
+  const domains = new Set<string>()
+  const variants = new Set<EdgeVariant>()
+  if (spec) {
+    for (const node of spec.nodes) {
+      if (node.kind !== 'boundary') kinds.add(node.kind)
+      if (node.domain && DOMAIN_PALETTE[node.domain]) domains.add(node.domain)
+    }
+    for (const edge of spec.edges) variants.add(edge.variant ?? 'data')
+  }
+
+  const kindList = spec ? [...kinds] : (Object.keys(KIND_LABEL) as NodeKind[])
+  const domainList = spec ? [...domains] : Object.keys(DOMAIN_PALETTE)
+  const variantList = spec ? [...variants] : (Object.keys(EDGE_STYLE) as EdgeVariant[])
+
+  return (
+    <div className="rfd-legend">
+      <LegendGroup title="Domains">
+        {domainList.map((domain) => (
+          <span key={domain} className="rfd-legend__item">
+            <span
+              className="rfd-legend__swatch"
+              style={{background: DOMAIN_PALETTE[domain]?.accent}}
+            />
+            {DOMAIN_TITLES[domain] ?? domain}
+          </span>
+        ))}
+      </LegendGroup>
+      <LegendGroup title="Nodes">
+        {kindList.map((kind) => (
+          <span key={kind} className="rfd-legend__item">
+            <span className="rfd-legend__glyph">
+              <DiagramIcon kind={kind} size={14} />
+            </span>
+            {KIND_LABEL[kind]}
+          </span>
+        ))}
+      </LegendGroup>
+      <LegendGroup title="Edges">
+        {variantList.map((variant) => {
+          const style = EDGE_STYLE[variant]
+          return (
+            <span key={variant} className="rfd-legend__item">
+              <svg width="26" height="10" aria-hidden="true">
+                <line
+                  x1="1"
+                  y1="5"
+                  x2="25"
+                  y2="5"
+                  stroke={style.stroke}
+                  strokeWidth={style.strokeWidth}
+                  strokeDasharray={style.dash}
+                />
+              </svg>
+              {EDGE_VARIANT_LABEL[variant]}
+            </span>
+          )
+        })}
+      </LegendGroup>
+    </div>
+  )
+}
+
+function LegendGroup({title, children}: {title: string; children: ReactElement[]}): ReactElement {
+  return (
+    <div className="rfd-legend__group">
+      <span className="rfd-legend__title">{title}</span>
+      <div className="rfd-legend__items">{children}</div>
+    </div>
+  )
+}
+</content>

--- a/skills/architecture-diagrams/reference/src/Legend.tsx
+++ b/skills/architecture-diagrams/reference/src/Legend.tsx
@@ -97,4 +97,3 @@ function LegendGroup({title, children}: {title: string; children: ReactElement[]
     </div>
   )
 }
-</content>

--- a/skills/architecture-diagrams/reference/src/Legend.tsx
+++ b/skills/architecture-diagrams/reference/src/Legend.tsx
@@ -11,7 +11,7 @@ const DOMAIN_TITLES: Record<string, string> = {
   auth: 'Auth / IdP',
   ingestion: 'Ingestion',
   planner: 'Planner',
-  ai: 'AI / Bedrock',
+  ai: 'AI / model',
   data: 'Data store',
   queue: 'Queue',
   event: 'Events',

--- a/skills/architecture-diagrams/reference/src/index.ts
+++ b/skills/architecture-diagrams/reference/src/index.ts
@@ -1,0 +1,34 @@
+export {DiagramViewer} from './DiagramViewer'
+export {DiagramCanvas} from './DiagramCanvas'
+export {ClientOnly} from './ClientOnly'
+export {Legend} from './Legend'
+
+export {runElkLayout} from './layout/elk'
+export type {LaidOutGraph} from './layout/elk'
+
+export {nodeTypes} from './nodes/nodes'
+export {DiagramIcon} from './theme/icons'
+export {RFD_STYLESHEET} from './theme/stylesheet'
+
+export {
+  DOMAIN_PALETTE,
+  EDGE_STYLE,
+  EDGE_VARIANT_LABEL,
+  KIND_LABEL,
+  NODE_SIZE,
+  domainColor,
+  nodeSize,
+} from './theme/tokens'
+export type {DomainColor, EdgeStyle} from './theme/tokens'
+
+export type {
+  DiagramDomain,
+  DiagramEdge,
+  DiagramLayout,
+  DiagramNode,
+  DiagramNodeData,
+  DiagramSpec,
+  EdgeVariant,
+  NodeKind,
+} from './types'
+</content>

--- a/skills/architecture-diagrams/reference/src/index.ts
+++ b/skills/architecture-diagrams/reference/src/index.ts
@@ -33,4 +33,3 @@ export type {
   EdgeVariant,
   NodeKind,
 } from './types'
-</content>

--- a/skills/architecture-diagrams/reference/src/index.ts
+++ b/skills/architecture-diagrams/reference/src/index.ts
@@ -7,6 +7,8 @@ export {runElkLayout} from './layout/elk'
 export type {LaidOutGraph} from './layout/elk'
 
 export {nodeTypes} from './nodes/nodes'
+export {edgeTypes, OrthogonalEdge, buildRoutePath} from './nodes/edges'
+export type {OrthogonalEdgeData, OrthogonalEdgeType, RoutePoint} from './nodes/edges'
 export {DiagramIcon} from './theme/icons'
 export {RFD_STYLESHEET} from './theme/stylesheet'
 

--- a/skills/architecture-diagrams/reference/src/layout/elk.ts
+++ b/skills/architecture-diagrams/reference/src/layout/elk.ts
@@ -1,0 +1,289 @@
+import {MarkerType, type Edge, type Node} from '@xyflow/react'
+import ELK, {type ElkNode} from 'elkjs/lib/elk.bundled.js'
+
+import {EDGE_STYLE, domainColor, nodeSize} from '../theme/tokens'
+import type {DiagramNode, DiagramNodeData, DiagramSpec} from '../types'
+
+export interface LaidOutGraph {
+  nodes: Node<DiagramNodeData>[]
+  edges: Edge[]
+}
+
+const ROOT_OPTIONS: Record<string, string> = {
+  'elk.algorithm': 'layered',
+  // Wide layer gaps give edge labels room to sit in the gap between layers
+  // instead of stacking on top of the bundled edges (the main readability win).
+  'elk.layered.spacing.nodeNodeBetweenLayers': '130',
+  'elk.spacing.nodeNode': '64',
+  'elk.layered.spacing.edgeNodeBetweenLayers': '34',
+  'elk.layered.spacing.edgeEdgeBetweenLayers': '16',
+  'elk.spacing.edgeNode': '28',
+  'elk.spacing.edgeEdge': '16',
+  'elk.layered.considerModelOrder.strategy': 'NODES_AND_EDGES',
+  'elk.layered.nodePlacement.strategy': 'NETWORK_SIMPLEX',
+  // Route edges orthogonally and KEEP the result: the rendered edges follow
+  // ELK's waypoints (see runElkLayout below), so they bend around nodes instead
+  // of cutting through them. Without consuming these, back/cycle edges wrap all
+  // the way around nodes and the diagram turns into a tangle.
+  'elk.edgeRouting': 'ORTHOGONAL',
+  // Let ELK place edge labels (centered, with breathing room) so they land in
+  // the inter-layer gap rather than colliding on top of the bundled edges.
+  'elk.edgeLabels.placement': 'CENTER',
+  'elk.spacing.edgeLabel': '6',
+  // Bias toward a balanced (less extreme) aspect ratio so wide fan-outs don't
+  // sprawl into a thin band with lots of dead canvas.
+  'elk.aspectRatio': '1.7',
+  'elk.hierarchyHandling': 'INCLUDE_CHILDREN',
+}
+
+/** Rough text width so ELK reserves the right gap for an edge label. */
+function estimateLabelWidth(text: string): number {
+  return Math.max(20, Math.round(text.length * 6.4 + 14))
+}
+
+/** Center of a polyline by arc length — fallback when ELK gives no label box. */
+function polylineMidpoint(points: {x: number; y: number}[]): {x: number; y: number} | undefined {
+  const first = points[0]
+  if (!first) return undefined
+  if (points.length === 1) return first
+
+  let total = 0
+  for (let i = 1; i < points.length; i++) {
+    const prev = points[i - 1]
+    const curr = points[i]
+    if (prev && curr) total += Math.hypot(curr.x - prev.x, curr.y - prev.y)
+  }
+
+  let walked = 0
+  for (let i = 1; i < points.length; i++) {
+    const prev = points[i - 1]
+    const curr = points[i]
+    if (!prev || !curr) continue
+    const seg = Math.hypot(curr.x - prev.x, curr.y - prev.y)
+    if (walked + seg >= total / 2) {
+      const t = seg === 0 ? 0 : (total / 2 - walked) / seg
+      return {x: prev.x + (curr.x - prev.x) * t, y: prev.y + (curr.y - prev.y) * t}
+    }
+    walked += seg
+  }
+
+  return points[points.length - 1] ?? first
+}
+
+/** ELK routing read back for one edge: waypoints + (optional) label center. */
+interface EdgeRouting {
+  points: {x: number; y: number}[]
+  labelX?: number
+  labelY?: number
+}
+
+/**
+ * Lay a DiagramSpec out with ELK and translate the result into React Flow
+ * nodes + styled edges. Boundary containers are nested via ELK hierarchy and
+ * become React Flow parent nodes (child positions stay relative to the parent).
+ */
+export async function runElkLayout(spec: DiagramSpec): Promise<LaidOutGraph> {
+  const direction = spec.layout?.direction ?? 'RIGHT'
+  const byId = new Map(spec.nodes.map((n) => [n.id, n]))
+
+  const childrenOf = new Map<string, DiagramNode[]>()
+  const roots: DiagramNode[] = []
+  for (const node of spec.nodes) {
+    const parent = node.parent && byId.has(node.parent) ? node.parent : undefined
+    if (parent) {
+      const siblings = childrenOf.get(parent) ?? []
+      siblings.push(node)
+      childrenOf.set(parent, siblings)
+    } else {
+      roots.push(node)
+    }
+  }
+
+  const isContainer = (node: DiagramNode): boolean =>
+    (childrenOf.get(node.id)?.length ?? 0) > 0 || node.kind === 'boundary'
+
+  const toElk = (node: DiagramNode): ElkNode => {
+    if (isContainer(node)) {
+      return {
+        id: node.id,
+        layoutOptions: {
+          'elk.padding': '[top=36,left=18,bottom=18,right=18]',
+          'elk.direction': direction,
+        },
+        children: (childrenOf.get(node.id) ?? []).map(toElk),
+      }
+    }
+
+    const {width, height} = nodeSize(node.kind)
+    return {id: node.id, width, height}
+  }
+
+  const graph: ElkNode = {
+    id: 'root',
+    layoutOptions: {...ROOT_OPTIONS, 'elk.direction': direction},
+    children: roots.map(toElk),
+    edges: spec.edges.map((edge) => ({
+      id: edge.id,
+      sources: [edge.source],
+      targets: [edge.target],
+      ...(edge.label
+        ? {
+            labels: [
+              {
+                id: `${edge.id}__label`,
+                text: edge.label,
+                width: estimateLabelWidth(edge.label),
+                height: 16,
+              },
+            ],
+          }
+        : {}),
+    })),
+  }
+
+  const laid = await new ELK().layout(graph)
+
+  const nodes: Node<DiagramNodeData>[] = []
+  const walk = (elkNode: ElkNode, parentId?: string): void => {
+    const node = byId.get(elkNode.id)
+    if (node) {
+      const fallback = nodeSize(node.kind)
+      const width = elkNode.width ?? fallback.width
+      const height = elkNode.height ?? fallback.height
+      // Set width/height on the node object (not just style) so React Flow seeds
+      // `measured` immediately and computes handle bounds — without this, edges
+      // have no anchor points and silently fail to render.
+      nodes.push({
+        id: node.id,
+        type: node.kind,
+        position: {x: elkNode.x ?? 0, y: elkNode.y ?? 0},
+        data: {node, direction},
+        width,
+        height,
+        style: {width, height},
+        ...(isContainer(node) ? {selectable: false} : {}),
+        ...(parentId ? {parentId, extent: 'parent' as const} : {}),
+      })
+    }
+
+    for (const child of elkNode.children ?? []) {
+      walk(child, elkNode.id)
+    }
+  }
+  for (const child of laid.children ?? []) {
+    walk(child)
+  }
+
+  // Read back ELK's routing. With INCLUDE_CHILDREN, ELK reports each edge's
+  // section/label coordinates relative to the LOWEST container that holds both
+  // endpoints (their common ancestor boundary) — not relative to the root. A
+  // boundary-internal edge (e.g. two children of `backend`) therefore comes back
+  // in backend-local coordinates and must be shifted by backend's absolute
+  // origin, or it renders detached from its nodes. We compute every node's
+  // absolute position, then translate each edge by its endpoints' common-ancestor
+  // offset into root (flow) coordinates — the space React Flow positions nodes in.
+  const absById = new Map<string, {x: number; y: number}>()
+  const computeAbs = (elkNode: ElkNode, ax: number, ay: number): void => {
+    absById.set(elkNode.id, {x: ax, y: ay})
+    for (const child of elkNode.children ?? []) {
+      computeAbs(child, ax + (child.x ?? 0), ay + (child.y ?? 0))
+    }
+  }
+  for (const child of laid.children ?? []) {
+    computeAbs(child, child.x ?? 0, child.y ?? 0)
+  }
+
+  // ELK can park an edge at any tree level, so collect every result edge by id.
+  const elkEdgeById = new Map<string, NonNullable<ElkNode['edges']>[number]>()
+  const collectElkEdges = (elkNode: ElkNode): void => {
+    for (const elkEdge of elkNode.edges ?? []) elkEdgeById.set(elkEdge.id, elkEdge)
+    for (const child of elkNode.children ?? []) collectElkEdges(child)
+  }
+  collectElkEdges(laid)
+
+  // Boundary chain (immediate parent → up) for a node, and the lowest common one.
+  const ancestorsOf = (id: string): string[] => {
+    const chain: string[] = []
+    let cur = byId.get(id)?.parent
+    while (cur && byId.has(cur)) {
+      chain.push(cur)
+      cur = byId.get(cur)?.parent
+    }
+    return chain
+  }
+  const commonAncestor = (a: string, b: string): string | undefined => {
+    const bAncestors = new Set(ancestorsOf(b))
+    return ancestorsOf(a).find((id) => bAncestors.has(id))
+  }
+
+  const routingFor = (edge: DiagramSpec['edges'][number]): EdgeRouting => {
+    const elkEdge = elkEdgeById.get(edge.id)
+    const anchor = commonAncestor(edge.source, edge.target)
+    const offset = (anchor ? absById.get(anchor) : undefined) ?? {x: 0, y: 0}
+
+    const section = elkEdge?.sections?.[0]
+    const points = section
+      ? [section.startPoint, ...(section.bendPoints ?? []), section.endPoint].map((p) => ({
+          x: p.x + offset.x,
+          y: p.y + offset.y,
+        }))
+      : []
+
+    const elkLabel = elkEdge?.labels?.[0]
+    if (elkLabel && elkLabel.x != null && elkLabel.y != null) {
+      return {
+        points,
+        labelX: elkLabel.x + offset.x + (elkLabel.width ?? 0) / 2,
+        labelY: elkLabel.y + offset.y + (elkLabel.height ?? 0) / 2,
+      }
+    }
+
+    const mid = polylineMidpoint(points)
+
+    return {points, labelX: mid?.x, labelY: mid?.y}
+  }
+
+  const edges: Edge[] = spec.edges.map((edge) => {
+    const variant = edge.variant ?? 'data'
+    const style = EDGE_STYLE[variant]
+    const routing = routingFor(edge)
+    const routed = routing.points.length >= 2
+    return {
+      id: edge.id,
+      source: edge.source,
+      target: edge.target,
+      sourceHandle: 'out',
+      targetHandle: 'in',
+      label: edge.label,
+      // Follow ELK's waypoints when we have them; fall back to React Flow's own
+      // smoothstep only if a route somehow came back empty.
+      type: routed ? 'orthogonal' : 'smoothstep',
+      ...(routed
+        ? {data: {points: routing.points, labelX: routing.labelX, labelY: routing.labelY}}
+        : {}),
+      animated: edge.animated ?? style.animated,
+      style: {stroke: style.stroke, strokeWidth: style.strokeWidth, strokeDasharray: style.dash},
+      markerEnd:
+        variant === 'dependency'
+          ? undefined
+          : {type: MarkerType.ArrowClosed, color: style.stroke, width: 15, height: 15},
+      // Opaque, bordered chip so a label stays legible even when it lands on or
+      // near another edge.
+      labelBgStyle: {
+        fill: 'var(--rfd-card)',
+        fillOpacity: 1,
+        stroke: 'var(--rfd-border)',
+        strokeWidth: 1,
+      },
+      labelStyle: {fill: 'var(--rfd-ink)', fontWeight: 600, fontSize: 11},
+      labelBgPadding: [7, 3],
+      labelBgBorderRadius: 6,
+    } satisfies Edge
+  })
+
+  return {nodes, edges}
+}
+
+// Re-exported for callers that want palette access alongside layout.
+export {domainColor}
+</content>

--- a/skills/architecture-diagrams/reference/src/layout/elk.ts
+++ b/skills/architecture-diagrams/reference/src/layout/elk.ts
@@ -286,4 +286,3 @@ export async function runElkLayout(spec: DiagramSpec): Promise<LaidOutGraph> {
 
 // Re-exported for callers that want palette access alongside layout.
 export {domainColor}
-</content>

--- a/skills/architecture-diagrams/reference/src/nodes/edges.tsx
+++ b/skills/architecture-diagrams/reference/src/nodes/edges.tsx
@@ -101,4 +101,3 @@ export const edgeTypes: EdgeTypes = {
 }
 
 export type OrthogonalEdgeType = Edge<OrthogonalEdgeData, 'orthogonal'>
-</content>

--- a/skills/architecture-diagrams/reference/src/nodes/edges.tsx
+++ b/skills/architecture-diagrams/reference/src/nodes/edges.tsx
@@ -1,0 +1,104 @@
+import {BaseEdge, type Edge, type EdgeProps, type EdgeTypes} from '@xyflow/react'
+import type {ReactElement} from 'react'
+
+/** A single waypoint in flow (absolute) coordinates. */
+export interface RoutePoint {
+  x: number
+  y: number
+}
+
+/**
+ * Geometry handed to {@link OrthogonalEdge} by the ELK layout pass. `points` is
+ * the full waypoint list ELK routed (start on the source border → bend points →
+ * end on the target border); `labelX/labelY` is the label center ELK reserved
+ * space for in the gap between layers.
+ */
+export interface OrthogonalEdgeData extends Record<string, unknown> {
+  points: RoutePoint[]
+  labelX?: number
+  labelY?: number
+}
+
+const dist = (a: RoutePoint, b: RoutePoint): number => Math.hypot(b.x - a.x, b.y - a.y)
+
+/** A point `r` units from `from` along the segment toward `to`. */
+function towards(from: RoutePoint, to: RoutePoint, r: number): RoutePoint {
+  const len = dist(from, to) || 1
+  return {x: from.x + ((to.x - from.x) / len) * r, y: from.y + ((to.y - from.y) / len) * r}
+}
+
+/**
+ * Build an SVG path through `points` with rounded corners. Each interior vertex
+ * becomes a quadratic curve whose radius is clamped to half the shorter adjacent
+ * segment, so tight bends stay clean and never overshoot. Works for ELK's
+ * orthogonal routes as well as any polyline.
+ */
+export function buildRoutePath(points: RoutePoint[], radius = 12): string {
+  const first = points[0]
+  const second = points[1]
+  if (!first || !second) return ''
+  if (points.length === 2) return `M ${first.x},${first.y} L ${second.x},${second.y}`
+
+  let d = `M ${first.x},${first.y}`
+  for (let i = 1; i < points.length - 1; i++) {
+    const prev = points[i - 1]
+    const curr = points[i]
+    const next = points[i + 1]
+    if (!prev || !curr || !next) continue
+    const r = Math.min(radius, dist(prev, curr) / 2, dist(curr, next) / 2)
+    const enter = towards(curr, prev, r)
+    const exit = towards(curr, next, r)
+    d += ` L ${enter.x},${enter.y} Q ${curr.x},${curr.y} ${exit.x},${exit.y}`
+  }
+  const last = points[points.length - 1]
+  if (last) d += ` L ${last.x},${last.y}`
+
+  return d
+}
+
+/**
+ * Renders an edge along the exact waypoints ELK computed, instead of letting
+ * React Flow re-derive a curve between fixed handles. This is what keeps edges
+ * from cutting across unrelated nodes or looping backward: the geometry is the
+ * layout engine's, not a naive handle-to-handle smoothstep.
+ */
+export function OrthogonalEdge(props: EdgeProps): ReactElement {
+  const {
+    id,
+    data,
+    style,
+    markerEnd,
+    label,
+    labelStyle,
+    labelBgStyle,
+    labelBgPadding,
+    labelBgBorderRadius,
+  } = props
+  const geometry = data as OrthogonalEdgeData | undefined
+  const points = geometry?.points ?? []
+  const path = buildRoutePath(points)
+
+  return (
+    <BaseEdge
+      id={id}
+      path={path}
+      style={style}
+      markerEnd={markerEnd}
+      label={label}
+      labelX={geometry?.labelX}
+      labelY={geometry?.labelY}
+      labelStyle={labelStyle}
+      labelShowBg={label != null}
+      labelBgStyle={labelBgStyle}
+      labelBgPadding={labelBgPadding}
+      labelBgBorderRadius={labelBgBorderRadius}
+    />
+  )
+}
+
+export const edgeTypes: EdgeTypes = {
+  orthogonal: OrthogonalEdge,
+}
+
+export type OrthogonalEdgeType = Edge<OrthogonalEdgeData, 'orthogonal'>
+</content>

--- a/skills/architecture-diagrams/reference/src/nodes/nodes.tsx
+++ b/skills/architecture-diagrams/reference/src/nodes/nodes.tsx
@@ -1,0 +1,73 @@
+import {Handle, Position, type NodeProps, type NodeTypes} from '@xyflow/react'
+import type {CSSProperties, ReactElement} from 'react'
+
+import {DiagramIcon} from '../theme/icons'
+import {domainColor} from '../theme/tokens'
+import type {DiagramNodeData} from '../types'
+
+function accentVars(domain?: string): CSSProperties {
+  const {accent, soft} = domainColor(domain)
+  return {'--rfd-accent': accent, '--rfd-soft': soft} as CSSProperties
+}
+
+/** Source/target handle positions for the active flow direction. */
+function handlePositions(direction: 'RIGHT' | 'DOWN'): {target: Position; source: Position} {
+  return direction === 'DOWN'
+    ? {target: Position.Top, source: Position.Bottom}
+    : {target: Position.Left, source: Position.Right}
+}
+
+/** Leaf node: service, datastore, queue, topic, external, process, client. */
+function LeafNode({data}: NodeProps): ReactElement {
+  const {node, direction} = data as DiagramNodeData
+  const pos = handlePositions(direction)
+  const metaEntries = node.meta ? Object.entries(node.meta).slice(0, 3) : []
+
+  return (
+    <div className="rfd-node" style={accentVars(node.domain)}>
+      <Handle className="rfd-handle" type="target" position={pos.target} id="in" />
+      <div className="rfd-node__bar" />
+      <div className="rfd-node__body">
+        <div className="rfd-node__head">
+          <span className="rfd-node__icon">
+            <DiagramIcon name={node.icon} kind={node.kind} />
+          </span>
+          <span className="rfd-node__title">{node.label}</span>
+        </div>
+        {node.sublabel ? <div className="rfd-node__sub">{node.sublabel}</div> : null}
+        {metaEntries.length > 0 ? (
+          <div className="rfd-node__meta">
+            {metaEntries.map(([key, value]) => (
+              <span key={key} className="rfd-chip" title={`${key}: ${value}`}>
+                {value}
+              </span>
+            ))}
+          </div>
+        ) : null}
+      </div>
+      <Handle className="rfd-handle" type="source" position={pos.source} id="out" />
+    </div>
+  )
+}
+
+/** Container that visually groups its child nodes. */
+function BoundaryNode({data}: NodeProps): ReactElement {
+  const {node} = data as DiagramNodeData
+  return (
+    <div className="rfd-boundary" style={accentVars(node.domain)}>
+      <span className="rfd-boundary__label">{node.label}</span>
+    </div>
+  )
+}
+
+export const nodeTypes: NodeTypes = {
+  service: LeafNode,
+  datastore: LeafNode,
+  queue: LeafNode,
+  topic: LeafNode,
+  external: LeafNode,
+  process: LeafNode,
+  client: LeafNode,
+  boundary: BoundaryNode,
+}
+</content>

--- a/skills/architecture-diagrams/reference/src/nodes/nodes.tsx
+++ b/skills/architecture-diagrams/reference/src/nodes/nodes.tsx
@@ -70,4 +70,3 @@ export const nodeTypes: NodeTypes = {
   client: LeafNode,
   boundary: BoundaryNode,
 }
-</content>

--- a/skills/architecture-diagrams/reference/src/theme/icons.tsx
+++ b/skills/architecture-diagrams/reference/src/theme/icons.tsx
@@ -164,4 +164,3 @@ export function DiagramIcon({
     </svg>
   )
 }
-</content>

--- a/skills/architecture-diagrams/reference/src/theme/icons.tsx
+++ b/skills/architecture-diagrams/reference/src/theme/icons.tsx
@@ -1,0 +1,167 @@
+import type {ReactElement} from 'react'
+
+import type {NodeKind} from '../types'
+
+/**
+ * A compact line-icon set. Keys can be referenced from `DiagramNode.icon`;
+ * otherwise a sensible glyph is derived from the node kind.
+ */
+const PATHS: Record<string, ReactElement> = {
+  service: (
+    <>
+      <rect x="3" y="4" width="14" height="5" rx="1.4" />
+      <rect x="3" y="11" width="14" height="5" rx="1.4" />
+      <path d="M6 6.5h0M6 13.5h0" />
+    </>
+  ),
+  worker: (
+    <>
+      <circle cx="10" cy="10" r="3" />
+      <path d="M10 3v2M10 15v2M3 10h2M15 10h2M5.2 5.2l1.4 1.4M13.4 13.4l1.4 1.4M14.8 5.2l-1.4 1.4M6.6 13.4l-1.4 1.4" />
+    </>
+  ),
+  lambda: <path d="M5 16l4-12 5 12M7.5 9h6" />,
+  datastore: (
+    <>
+      <ellipse cx="10" cy="5.5" rx="6" ry="2.4" />
+      <path d="M4 5.5v9c0 1.3 2.7 2.4 6 2.4s6-1.1 6-2.4v-9" />
+      <path d="M4 10c0 1.3 2.7 2.4 6 2.4s6-1.1 6-2.4" />
+    </>
+  ),
+  bucket: (
+    <>
+      <path d="M4 5h12l-1.2 11.2a1 1 0 0 1-1 .8H6.2a1 1 0 0 1-1-.8z" />
+      <path d="M4 5h12" />
+    </>
+  ),
+  queue: (
+    <>
+      <rect x="3" y="6" width="3.4" height="8" rx="1" />
+      <rect x="8.3" y="6" width="3.4" height="8" rx="1" />
+      <rect x="13.6" y="6" width="3.4" height="8" rx="1" />
+    </>
+  ),
+  topic: (
+    <>
+      <circle cx="6" cy="10" r="2.2" />
+      <path d="M8 9l6-3M8 11l6 3" />
+      <circle cx="15" cy="5.5" r="1.8" />
+      <circle cx="15" cy="14.5" r="1.8" />
+    </>
+  ),
+  event: <path d="M11 3L4 11h5l-1 6 7-8h-5z" />,
+  external: (
+    <>
+      <circle cx="10" cy="10" r="7" />
+      <path d="M3 10h14M10 3c2 2 2 12 0 14M10 3c-2 2-2 12 0 14" />
+    </>
+  ),
+  process: (
+    <>
+      <path d="M3 7h9l3 3-3 3H3z" />
+      <path d="M12 7l3 3-3 3" />
+    </>
+  ),
+  client: (
+    <>
+      <rect x="3" y="4" width="14" height="9" rx="1.4" />
+      <path d="M7 16h6M10 13v3" />
+    </>
+  ),
+  browser: (
+    <>
+      <rect x="3" y="4" width="14" height="12" rx="1.6" />
+      <path d="M3 7.5h14M5.5 5.7h0M7.3 5.7h0" />
+    </>
+  ),
+  brain: (
+    <>
+      <path d="M8.5 4a2.4 2.4 0 0 0-2.4 2.4A2.2 2.2 0 0 0 5 10a2.3 2.3 0 0 0 1.4 3.6A2.2 2.2 0 0 0 8.5 16" />
+      <path d="M11.5 4a2.4 2.4 0 0 1 2.4 2.4A2.2 2.2 0 0 1 15 10a2.3 2.3 0 0 1-1.4 3.6A2.2 2.2 0 0 1 11.5 16" />
+      <path d="M10 4v12" />
+    </>
+  ),
+  ai: (
+    <>
+      <rect x="4" y="4" width="12" height="12" rx="2.5" />
+      <path d="M7.5 13V8l2.5 3 2.5-3v5" />
+    </>
+  ),
+  shield: <path d="M10 3l6 2v4c0 4-2.6 6.7-6 8-3.4-1.3-6-4-6-8V5z" />,
+  user: (
+    <>
+      <circle cx="10" cy="7" r="3" />
+      <path d="M4.5 16c.9-2.5 2.7-3.8 5.5-3.8s4.6 1.3 5.5 3.8" />
+    </>
+  ),
+  search: (
+    <>
+      <circle cx="9" cy="9" r="5" />
+      <path d="M13 13l4 4" />
+    </>
+  ),
+  catalog: (
+    <>
+      <rect x="4" y="3" width="12" height="14" rx="1.4" />
+      <path d="M7 6h6M7 9h6M7 12h4" />
+    </>
+  ),
+  schedule: (
+    <>
+      <circle cx="10" cy="10" r="6.5" />
+      <path d="M10 6v4l3 2" />
+    </>
+  ),
+  metrics: <path d="M3 16V8M8 16V4M13 16v-6M3 16h14" />,
+  gear: (
+    <>
+      <circle cx="10" cy="10" r="2.6" />
+      <path d="M10 3v2.2M10 14.8V17M3 10h2.2M14.8 10H17M5.2 5.2l1.6 1.6M13.2 13.2l1.6 1.6M14.8 5.2l-1.6 1.6M6.8 13.2l-1.6 1.6" />
+    </>
+  ),
+  cookie: (
+    <>
+      <path d="M10 3a7 7 0 1 0 7 7 3 3 0 0 1-3-3 3 3 0 0 1-3-3 4 4 0 0 0-1-1z" />
+      <path d="M8 9h0M11.5 11.5h0M7.5 13h0" />
+    </>
+  ),
+}
+
+const KIND_DEFAULT: Record<NodeKind, string> = {
+  service: 'service',
+  datastore: 'datastore',
+  queue: 'queue',
+  topic: 'topic',
+  external: 'external',
+  process: 'process',
+  client: 'client',
+  boundary: 'gear',
+}
+
+export function DiagramIcon({
+  name,
+  kind,
+  size = 18,
+}: {
+  name?: string
+  kind: NodeKind
+  size?: number
+}): ReactElement {
+  const key = (name && PATHS[name] ? name : KIND_DEFAULT[kind]) || 'service'
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 20 20"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      {PATHS[key]}
+    </svg>
+  )
+}
+</content>

--- a/skills/architecture-diagrams/reference/src/theme/stylesheet.ts
+++ b/skills/architecture-diagrams/reference/src/theme/stylesheet.ts
@@ -1,26 +1,27 @@
 /**
  * One self-contained stylesheet for the whole toolkit. Injected once by the
- * canvas so the package needs no Tailwind or external CSS in the consuming app.
- * Theme-derived colors read the host's `--pg-*` CSS vars (set by
- * @photon-grove/react-ui's ThemeProvider) with safe standalone fallbacks.
+ * viewer so the package needs no Tailwind or external CSS in the consuming app.
+ * Theme-derived colors read host `--app-*` CSS vars (set by your app's theme
+ * provider, if any) with safe standalone fallbacks.
  *
- * PORTABILITY: to theme this in another app, either define `--pg-ink`,
- * `--pg-shell`, `--pg-border`, `--pg-subtle`, `--pg-hover`, `--pg-font-sans`
- * (and optionally `--pg-palette-accent` / `--hm-accent`) on a wrapping element,
- * or rename the `var(--pg-*, …)` references below to your own design tokens.
- * The hard-coded fallbacks make it render correctly with no tokens at all.
+ * PORTABILITY: to theme this in your app, either define `--app-ink`,
+ * `--app-surface`, `--app-border`, `--app-subtle`, `--app-hover`,
+ * `--app-font-sans` (and optionally `--app-accent`) on a wrapping element, or
+ * rename the `var(--app-*, …)` references below to whatever design tokens you
+ * already use. The hard-coded fallbacks make it render correctly with no tokens
+ * at all, and dark mode works automatically if your tokens flip.
  */
 export const RFD_STYLESHEET = `
 .rfd-root {
-  --rfd-ink: var(--pg-ink, #0f172a);
-  --rfd-muted: var(--pg-muted, rgba(15,23,42,0.62));
-  --rfd-card: var(--pg-shell, #ffffff);
-  --rfd-border: var(--pg-border, rgba(100,116,139,0.22));
-  --rfd-canvas: color-mix(in srgb, var(--pg-ink, #0f172a) 5%, var(--pg-shell, #ffffff));
-  --rfd-edge: var(--pg-subtle, #64748b);
-  --rfd-edge-strong: var(--hm-accent, var(--pg-palette-accent, #818cf8));
-  --rfd-edge-muted: color-mix(in srgb, var(--pg-ink, #64748b) 38%, transparent);
-  --rfd-handle-ring: var(--pg-shell, #ffffff);
+  --rfd-ink: var(--app-ink, #0f172a);
+  --rfd-muted: var(--app-muted, rgba(15,23,42,0.62));
+  --rfd-card: var(--app-surface, #ffffff);
+  --rfd-border: var(--app-border, rgba(100,116,139,0.22));
+  --rfd-canvas: color-mix(in srgb, var(--app-ink, #0f172a) 5%, var(--app-surface, #ffffff));
+  --rfd-edge: var(--app-subtle, #64748b);
+  --rfd-edge-strong: var(--app-accent, #818cf8);
+  --rfd-edge-muted: color-mix(in srgb, var(--app-ink, #64748b) 38%, transparent);
+  --rfd-handle-ring: var(--app-surface, #ffffff);
   width: 100%;
   height: 100%;
 }
@@ -108,13 +109,13 @@ export const RFD_STYLESHEET = `
   height: 100%;
   min-height: 0;
   color: var(--rfd-ink);
-  font-family: var(--pg-font-sans, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif);
+  font-family: var(--app-font-sans, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif);
 }
 .rfd-viewer__nav {
   display: flex; flex-direction: column; gap: 6px;
   padding: 16px 12px; overflow-y: auto;
   border-right: 1px solid var(--rfd-border);
-  background: color-mix(in srgb, var(--pg-ink, #0f172a) 3%, var(--pg-shell, #fff));
+  background: color-mix(in srgb, var(--app-ink, #0f172a) 3%, var(--app-surface, #fff));
 }
 .rfd-viewer__brand { display: flex; flex-direction: column; gap: 2px; padding: 4px 8px 12px; }
 .rfd-viewer__brand-title { font-size: 15px; font-weight: 750; letter-spacing: -0.01em; }
@@ -130,7 +131,7 @@ export const RFD_STYLESHEET = `
   background: transparent; cursor: pointer; color: inherit; width: 100%;
   transition: background 0.15s ease, border-color 0.15s ease;
 }
-.rfd-viewer__item:hover { background: var(--pg-hover, rgba(100,116,139,0.1)); }
+.rfd-viewer__item:hover { background: var(--app-hover, rgba(100,116,139,0.1)); }
 .rfd-viewer__item--active {
   background: var(--rfd-card);
   border-color: var(--rfd-border);
@@ -148,7 +149,7 @@ export const RFD_STYLESHEET = `
 .rfd-viewer__main { display: flex; flex-direction: column; min-width: 0; min-height: 0; }
 .rfd-viewer__header {
   padding: 20px 24px 15px; border-bottom: 1px solid var(--rfd-border);
-  background: color-mix(in srgb, var(--pg-ink, #0f172a) 2%, var(--pg-shell, #fff));
+  background: color-mix(in srgb, var(--app-ink, #0f172a) 2%, var(--app-surface, #fff));
 }
 .rfd-viewer__title { margin: 0; font-size: 22px; font-weight: 760; letter-spacing: -0.02em; }
 .rfd-viewer__desc { margin: 6px 0 0; font-size: 13px; line-height: 1.45; color: var(--rfd-muted); max-width: 76ch; }
@@ -162,7 +163,7 @@ export const RFD_STYLESHEET = `
 .rfd-legend {
   display: flex; flex-wrap: wrap; gap: 8px 26px;
   padding: 12px 22px; border-top: 1px solid var(--rfd-border);
-  background: color-mix(in srgb, var(--pg-ink, #0f172a) 3%, var(--pg-shell, #fff));
+  background: color-mix(in srgb, var(--app-ink, #0f172a) 3%, var(--app-surface, #fff));
 }
 .rfd-legend__group { display: flex; align-items: center; gap: 12px; min-width: 0; }
 .rfd-legend__title {

--- a/skills/architecture-diagrams/reference/src/theme/stylesheet.ts
+++ b/skills/architecture-diagrams/reference/src/theme/stylesheet.ts
@@ -1,0 +1,182 @@
+/**
+ * One self-contained stylesheet for the whole toolkit. Injected once by the
+ * canvas so the package needs no Tailwind or external CSS in the consuming app.
+ * Theme-derived colors read the host's `--pg-*` CSS vars (set by
+ * @photon-grove/react-ui's ThemeProvider) with safe standalone fallbacks.
+ *
+ * PORTABILITY: to theme this in another app, either define `--pg-ink`,
+ * `--pg-shell`, `--pg-border`, `--pg-subtle`, `--pg-hover`, `--pg-font-sans`
+ * (and optionally `--pg-palette-accent` / `--hm-accent`) on a wrapping element,
+ * or rename the `var(--pg-*, …)` references below to your own design tokens.
+ * The hard-coded fallbacks make it render correctly with no tokens at all.
+ */
+export const RFD_STYLESHEET = `
+.rfd-root {
+  --rfd-ink: var(--pg-ink, #0f172a);
+  --rfd-muted: var(--pg-muted, rgba(15,23,42,0.62));
+  --rfd-card: var(--pg-shell, #ffffff);
+  --rfd-border: var(--pg-border, rgba(100,116,139,0.22));
+  --rfd-canvas: color-mix(in srgb, var(--pg-ink, #0f172a) 5%, var(--pg-shell, #ffffff));
+  --rfd-edge: var(--pg-subtle, #64748b);
+  --rfd-edge-strong: var(--hm-accent, var(--pg-palette-accent, #818cf8));
+  --rfd-edge-muted: color-mix(in srgb, var(--pg-ink, #64748b) 38%, transparent);
+  --rfd-handle-ring: var(--pg-shell, #ffffff);
+  width: 100%;
+  height: 100%;
+}
+.rfd-root .react-flow {
+  background:
+    radial-gradient(125% 90% at 50% -12%, color-mix(in srgb, var(--rfd-edge-strong) 11%, transparent), transparent 58%),
+    var(--rfd-canvas);
+}
+.rfd-node {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  border-radius: 15px;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--rfd-accent) 7%, transparent), transparent 44%),
+    var(--rfd-card);
+  border: 1px solid color-mix(in srgb, var(--rfd-accent) 22%, var(--rfd-border));
+  box-shadow: 0 1px 2px rgba(8,12,28,0.08), 0 16px 30px -16px rgba(8,12,28,0.5);
+  overflow: hidden;
+  transition: box-shadow 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
+}
+.rfd-node:hover {
+  border-color: color-mix(in srgb, var(--rfd-accent) 48%, var(--rfd-border));
+  box-shadow: 0 2px 6px rgba(8,12,28,0.14), 0 24px 46px -18px rgba(8,12,28,0.62),
+              0 0 0 3px color-mix(in srgb, var(--rfd-accent) 15%, transparent);
+  transform: translateY(-2px);
+}
+.rfd-node__bar {
+  height: 3px;
+  background: linear-gradient(90deg, var(--rfd-accent), color-mix(in srgb, var(--rfd-accent) 28%, transparent) 72%, transparent);
+  box-shadow: 0 0 14px -2px var(--rfd-accent);
+}
+.rfd-node__body { padding: 11px 13px; display: flex; flex-direction: column; gap: 5px; height: calc(100% - 3px); box-sizing: border-box; }
+.rfd-node__head { display: flex; align-items: center; gap: 10px; }
+.rfd-node__icon {
+  width: 32px; height: 32px; border-radius: 10px; flex: 0 0 auto;
+  display: flex; align-items: center; justify-content: center;
+  color: var(--rfd-accent);
+  background: linear-gradient(140deg, color-mix(in srgb, var(--rfd-accent) 28%, transparent), color-mix(in srgb, var(--rfd-accent) 9%, transparent));
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--rfd-accent) 32%, transparent);
+}
+.rfd-node__title { font-weight: 670; font-size: 14px; line-height: 1.2; color: var(--rfd-ink); letter-spacing: -0.01em; }
+.rfd-node__sub { font-size: 12px; line-height: 1.3; color: var(--rfd-muted); }
+.rfd-node__meta { margin-top: auto; display: flex; flex-wrap: wrap; gap: 4px; padding-top: 2px; }
+.rfd-chip {
+  font-size: 10px; padding: 2px 7px; border-radius: 999px;
+  background: var(--rfd-soft); color: var(--rfd-accent); font-weight: 600;
+  white-space: nowrap; max-width: 100%; overflow: hidden; text-overflow: ellipsis;
+}
+.rfd-handle {
+  /* Anchors React Flow still needs, but the visible line is ELK's routed path,
+     which touches the node border wherever ELK chose to attach it. A fixed
+     left/right dot next to a top/bottom-entering line reads as detached, so the
+     dot is hidden and the path itself is the connection. */
+  width: 8px; height: 8px; border-radius: 999px;
+  background: var(--rfd-accent); border: 2px solid var(--rfd-handle-ring);
+  opacity: 0;
+}
+.rfd-boundary {
+  position: relative; width: 100%; height: 100%; border-radius: 20px;
+  border: 1px solid color-mix(in srgb, var(--rfd-accent) 34%, transparent);
+  background: linear-gradient(180deg, color-mix(in srgb, var(--rfd-accent) 9%, transparent), color-mix(in srgb, var(--rfd-accent) 3%, transparent));
+}
+.rfd-boundary__label {
+  position: absolute; top: -11px; left: 16px;
+  display: inline-flex; align-items: center;
+  padding: 3px 11px; border-radius: 999px;
+  font-size: 10.5px; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase;
+  color: #fff;
+  background: color-mix(in srgb, var(--rfd-accent) 90%, #000);
+  box-shadow: 0 4px 12px -4px color-mix(in srgb, var(--rfd-accent) 70%, transparent);
+}
+.rfd-root .react-flow__edge-text { font-size: 11px; font-weight: 600; fill: var(--rfd-ink); }
+.rfd-root .react-flow__edge-textbg { fill: var(--rfd-card); opacity: 1; }
+.rfd-root .react-flow__controls { box-shadow: 0 6px 18px -8px rgba(10,15,30,0.4); border-radius: 10px; overflow: hidden; }
+.rfd-root .react-flow__controls-button { background: var(--rfd-card); border-bottom: 1px solid var(--rfd-border); color: var(--rfd-ink); }
+.rfd-root .react-flow__controls-button svg { fill: var(--rfd-ink); }
+.rfd-root .react-flow__minimap { border-radius: 10px; overflow: hidden; border: 1px solid var(--rfd-border); }
+
+/* ---- Viewer chrome ---- */
+.rfd-viewer {
+  display: grid;
+  grid-template-columns: 290px minmax(0, 1fr);
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  color: var(--rfd-ink);
+  font-family: var(--pg-font-sans, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif);
+}
+.rfd-viewer__nav {
+  display: flex; flex-direction: column; gap: 6px;
+  padding: 16px 12px; overflow-y: auto;
+  border-right: 1px solid var(--rfd-border);
+  background: color-mix(in srgb, var(--pg-ink, #0f172a) 3%, var(--pg-shell, #fff));
+}
+.rfd-viewer__brand { display: flex; flex-direction: column; gap: 2px; padding: 4px 8px 12px; }
+.rfd-viewer__brand-title { font-size: 15px; font-weight: 750; letter-spacing: -0.01em; }
+.rfd-viewer__brand-sub { font-size: 11.5px; color: var(--rfd-muted); }
+.rfd-viewer__group { display: flex; flex-direction: column; gap: 4px; margin-top: 8px; }
+.rfd-viewer__group-title {
+  font-size: 10px; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase;
+  color: var(--rfd-muted); padding: 4px 8px;
+}
+.rfd-viewer__item {
+  display: flex; align-items: flex-start; gap: 10px; text-align: left;
+  padding: 9px 10px; border-radius: 11px; border: 1px solid transparent;
+  background: transparent; cursor: pointer; color: inherit; width: 100%;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+.rfd-viewer__item:hover { background: var(--pg-hover, rgba(100,116,139,0.1)); }
+.rfd-viewer__item--active {
+  background: var(--rfd-card);
+  border-color: var(--rfd-border);
+  box-shadow: 0 8px 22px -14px rgba(10,15,30,0.45);
+}
+.rfd-viewer__item-index {
+  flex: 0 0 auto; width: 22px; height: 22px; border-radius: 7px;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 11px; font-weight: 700;
+  background: var(--rfd-edge-strong); color: #fff;
+}
+.rfd-viewer__item-body { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.rfd-viewer__item-title { font-size: 13px; font-weight: 620; line-height: 1.2; }
+.rfd-viewer__item-desc { font-size: 11px; line-height: 1.3; color: var(--rfd-muted); }
+.rfd-viewer__main { display: flex; flex-direction: column; min-width: 0; min-height: 0; }
+.rfd-viewer__header {
+  padding: 20px 24px 15px; border-bottom: 1px solid var(--rfd-border);
+  background: color-mix(in srgb, var(--pg-ink, #0f172a) 2%, var(--pg-shell, #fff));
+}
+.rfd-viewer__title { margin: 0; font-size: 22px; font-weight: 760; letter-spacing: -0.02em; }
+.rfd-viewer__desc { margin: 6px 0 0; font-size: 13px; line-height: 1.45; color: var(--rfd-muted); max-width: 76ch; }
+.rfd-viewer__canvas { position: relative; flex: 1 1 auto; min-height: 0; }
+.rfd-canvas__loading {
+  display: flex; align-items: center; justify-content: center; height: 100%;
+  color: var(--rfd-muted); font-size: 13px;
+}
+
+/* ---- Legend ---- */
+.rfd-legend {
+  display: flex; flex-wrap: wrap; gap: 8px 26px;
+  padding: 12px 22px; border-top: 1px solid var(--rfd-border);
+  background: color-mix(in srgb, var(--pg-ink, #0f172a) 3%, var(--pg-shell, #fff));
+}
+.rfd-legend__group { display: flex; align-items: center; gap: 12px; min-width: 0; }
+.rfd-legend__title {
+  font-size: 10px; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase;
+  color: var(--rfd-muted);
+}
+.rfd-legend__items { display: flex; flex-wrap: wrap; gap: 6px 14px; }
+.rfd-legend__item { display: inline-flex; align-items: center; gap: 6px; font-size: 11.5px; color: var(--rfd-ink); }
+.rfd-legend__swatch { width: 11px; height: 11px; border-radius: 4px; }
+.rfd-legend__glyph { display: inline-flex; color: var(--rfd-muted); }
+
+@media (max-width: 760px) {
+  .rfd-viewer { grid-template-columns: 1fr; grid-template-rows: auto minmax(0, 1fr); }
+  .rfd-viewer__nav { flex-direction: row; flex-wrap: nowrap; overflow-x: auto; border-right: none; border-bottom: 1px solid var(--rfd-border); }
+}
+`
+</content>

--- a/skills/architecture-diagrams/reference/src/theme/stylesheet.ts
+++ b/skills/architecture-diagrams/reference/src/theme/stylesheet.ts
@@ -180,4 +180,3 @@ export const RFD_STYLESHEET = `
   .rfd-viewer__nav { flex-direction: row; flex-wrap: nowrap; overflow-x: auto; border-right: none; border-bottom: 1px solid var(--rfd-border); }
 }
 `
-</content>

--- a/skills/architecture-diagrams/reference/src/theme/tokens.ts
+++ b/skills/architecture-diagrams/reference/src/theme/tokens.ts
@@ -81,8 +81,8 @@ export const EDGE_VARIANT_LABEL: Record<EdgeVariant, string> = {
 export const KIND_LABEL: Record<NodeKind, string> = {
   service: 'Service / worker',
   datastore: 'Data store',
-  queue: 'Queue (SQS)',
-  topic: 'Topic / bus (SNS)',
+  queue: 'Queue',
+  topic: 'Topic / event bus',
   external: 'External system',
   process: 'Pipeline step',
   client: 'Client surface',

--- a/skills/architecture-diagrams/reference/src/theme/tokens.ts
+++ b/skills/architecture-diagrams/reference/src/theme/tokens.ts
@@ -1,0 +1,91 @@
+import type {EdgeVariant, NodeKind} from '../types'
+
+/**
+ * Domain → color. Drives the accent bar, icon chip, and minimap dot of a node.
+ * `accent` is the strong line/icon color; `soft` is a translucent fill used
+ * behind the icon and as the node's top gradient. Colors are chosen to read
+ * well on both light and dark surfaces.
+ */
+export interface DomainColor {
+  accent: string
+  soft: string
+}
+
+export const DOMAIN_PALETTE: Record<string, DomainColor> = {
+  web: {accent: '#38bdf8', soft: 'rgba(56,189,248,0.16)'},
+  client: {accent: '#22d3ee', soft: 'rgba(34,211,238,0.16)'},
+  api: {accent: '#a78bfa', soft: 'rgba(167,139,250,0.18)'},
+  auth: {accent: '#f472b6', soft: 'rgba(244,114,182,0.16)'},
+  ingestion: {accent: '#34d399', soft: 'rgba(52,211,153,0.16)'},
+  planner: {accent: '#fbbf24', soft: 'rgba(251,191,36,0.18)'},
+  ai: {accent: '#c084fc', soft: 'rgba(192,132,252,0.18)'},
+  data: {accent: '#60a5fa', soft: 'rgba(96,165,250,0.16)'},
+  queue: {accent: '#fb923c', soft: 'rgba(251,146,60,0.18)'},
+  event: {accent: '#f59e0b', soft: 'rgba(245,158,11,0.16)'},
+  external: {accent: '#94a3b8', soft: 'rgba(148,163,184,0.16)'},
+  observability: {accent: '#4ade80', soft: 'rgba(74,222,128,0.14)'},
+  domain: {accent: '#818cf8', soft: 'rgba(129,140,248,0.18)'},
+}
+
+const NEUTRAL: DomainColor = {accent: '#94a3b8', soft: 'rgba(148,163,184,0.16)'}
+
+export function domainColor(domain?: string): DomainColor {
+  const hit = domain ? DOMAIN_PALETTE[domain] : undefined
+  return hit ?? NEUTRAL
+}
+
+/** Fixed render box per kind. Boundary containers are sized by ELK from children. */
+export const NODE_SIZE: Record<Exclude<NodeKind, 'boundary'>, {width: number; height: number}> = {
+  service: {width: 248, height: 96},
+  datastore: {width: 224, height: 96},
+  queue: {width: 224, height: 88},
+  topic: {width: 224, height: 88},
+  external: {width: 226, height: 90},
+  process: {width: 238, height: 88},
+  client: {width: 230, height: 94},
+}
+
+export function nodeSize(kind: NodeKind): {width: number; height: number} {
+  if (kind === 'boundary') return {width: 320, height: 200}
+  return NODE_SIZE[kind]
+}
+
+export interface EdgeStyle {
+  stroke: string
+  strokeWidth: number
+  dash?: string
+  animated: boolean
+}
+
+export const EDGE_STYLE: Record<EdgeVariant, EdgeStyle> = {
+  data: {stroke: 'var(--rfd-edge, #64748b)', strokeWidth: 1.6, animated: false},
+  request: {stroke: 'var(--rfd-edge-strong, #818cf8)', strokeWidth: 1.8, animated: false},
+  event: {stroke: '#f59e0b', strokeWidth: 1.8, animated: true},
+  async: {stroke: '#fb923c', strokeWidth: 1.8, dash: '6 5', animated: true},
+  dependency: {
+    stroke: 'var(--rfd-edge-muted, #94a3b8)',
+    strokeWidth: 1.4,
+    dash: '2 5',
+    animated: false,
+  },
+}
+
+export const EDGE_VARIANT_LABEL: Record<EdgeVariant, string> = {
+  data: 'Data flow',
+  request: 'Request / response',
+  event: 'Event emitted',
+  async: 'Async queue hand-off',
+  dependency: 'Dependency / reference',
+}
+
+export const KIND_LABEL: Record<NodeKind, string> = {
+  service: 'Service / worker',
+  datastore: 'Data store',
+  queue: 'Queue (SQS)',
+  topic: 'Topic / bus (SNS)',
+  external: 'External system',
+  process: 'Pipeline step',
+  client: 'Client surface',
+  boundary: 'Boundary',
+}
+</content>

--- a/skills/architecture-diagrams/reference/src/theme/tokens.ts
+++ b/skills/architecture-diagrams/reference/src/theme/tokens.ts
@@ -34,7 +34,11 @@ export function domainColor(domain?: string): DomainColor {
   return hit ?? NEUTRAL
 }
 
-/** Fixed render box per kind. Boundary containers are sized by ELK from children. */
+/**
+ * Fixed render box per kind. Boundary containers are normally sized by ELK from
+ * their children; `nodeSize('boundary')` returns a fixed box only as a fallback
+ * (e.g. an empty boundary, or before layout runs).
+ */
 export const NODE_SIZE: Record<Exclude<NodeKind, 'boundary'>, {width: number; height: number}> = {
   service: {width: 248, height: 96},
   datastore: {width: 224, height: 96},
@@ -88,4 +92,3 @@ export const KIND_LABEL: Record<NodeKind, string> = {
   client: 'Client surface',
   boundary: 'Boundary',
 }
-</content>

--- a/skills/architecture-diagrams/reference/src/types.ts
+++ b/skills/architecture-diagrams/reference/src/types.ts
@@ -1,0 +1,83 @@
+/**
+ * The diagram data contract.
+ *
+ * This is the schema that diagram *data* files (or an LLM) populate. The
+ * package owns the visual system and layout; callers only supply semantic
+ * nodes and edges. Keep this stable — it is the public, reusable interface.
+ */
+
+/** Visual category of a node. Drives which component renders it. */
+export type NodeKind =
+  | 'service' // a running service / lambda / worker
+  | 'datastore' // a database / table / bucket
+  | 'queue' // an async work queue (SQS)
+  | 'topic' // a pub/sub topic (SNS) / event bus
+  | 'external' // a third-party system outside our boundary
+  | 'process' // a pipeline step / stage / function
+  | 'client' // a browser / device / user-facing surface
+  | 'boundary' // a container that groups child nodes
+
+/**
+ * A semantic domain used to color-code nodes. Free-form, but the built-in
+ * palette knows the common ones (see DOMAIN_PALETTE). Unknown domains fall
+ * back to a neutral color.
+ */
+export type DiagramDomain = string
+
+export interface DiagramNode {
+  id: string
+  kind: NodeKind
+  label: string
+  /** Secondary line under the label (e.g. tech, table name, ARN suffix). */
+  sublabel?: string
+  /** Color-coding bucket. See DOMAIN_PALETTE for built-in keys. */
+  domain?: DiagramDomain
+  /** Icon slot key (see ICONS). Falls back to a kind-derived glyph. */
+  icon?: string
+  /** Parent boundary node id — nests this node inside a container. */
+  parent?: string
+  /** Arbitrary key/value detail surfaced on hover / in a side panel. */
+  meta?: Record<string, string>
+}
+
+/** Visual + semantic flavor of an edge. */
+export type EdgeVariant =
+  | 'data' // synchronous data flow
+  | 'request' // a request/response call
+  | 'event' // an emitted event / stream record
+  | 'async' // async hand-off through a queue (dashed, animated)
+  | 'dependency' // a soft dependency / reference (dotted)
+
+export interface DiagramEdge {
+  id: string
+  source: string
+  target: string
+  label?: string
+  variant?: EdgeVariant
+  /** Force animation on/off; defaults are derived from the variant. */
+  animated?: boolean
+}
+
+export interface DiagramLayout {
+  /** Primary flow direction. 'RIGHT' = left-to-right (default), 'DOWN' = top-to-bottom. */
+  direction?: 'RIGHT' | 'DOWN'
+}
+
+export interface DiagramSpec {
+  id: string
+  title: string
+  /** Short caption shown in the viewer header and the diagram picker. */
+  description?: string
+  /** Optional grouping label for the picker sidebar. */
+  group?: string
+  layout?: DiagramLayout
+  nodes: DiagramNode[]
+  edges: DiagramEdge[]
+}
+
+/** Data carried into a custom React Flow node component. */
+export interface DiagramNodeData extends Record<string, unknown> {
+  node: DiagramNode
+  direction: 'RIGHT' | 'DOWN'
+}
+</content>

--- a/skills/architecture-diagrams/reference/src/types.ts
+++ b/skills/architecture-diagrams/reference/src/types.ts
@@ -36,7 +36,10 @@ export interface DiagramNode {
   icon?: string
   /** Parent boundary node id — nests this node inside a container. */
   parent?: string
-  /** Arbitrary key/value detail surfaced on hover / in a side panel. */
+  /**
+   * Arbitrary key/value detail. The first up-to-3 entries render as chips on the
+   * node card (the value is shown; the key appears in the chip's hover tooltip).
+   */
   meta?: Record<string, string>
 }
 
@@ -80,4 +83,3 @@ export interface DiagramNodeData extends Record<string, unknown> {
   node: DiagramNode
   direction: 'RIGHT' | 'DOWN'
 }
-</content>

--- a/skills/architecture-diagrams/reference/src/types.ts
+++ b/skills/architecture-diagrams/reference/src/types.ts
@@ -10,8 +10,8 @@
 export type NodeKind =
   | 'service' // a running service / lambda / worker
   | 'datastore' // a database / table / bucket
-  | 'queue' // an async work queue (SQS)
-  | 'topic' // a pub/sub topic (SNS) / event bus
+  | 'queue' // an async work queue
+  | 'topic' // a pub/sub topic / event bus
   | 'external' // a third-party system outside our boundary
   | 'process' // a pipeline step / stage / function
   | 'client' // a browser / device / user-facing surface


### PR DESCRIPTION
## Summary

Adds a reusable **`architecture-diagrams`** skill: a guide plus a self-contained, copy-paste toolkit for building an interactive, auto-laid-out architecture-diagram docs page (sidebar picker, zoom/pan/minimap canvas, themed nodes, routed edges, legend).

It's framework-agnostic — the rendering toolkit is plain React + two libraries ([`@xyflow/react`](https://reactflow.dev) and [`elkjs`](https://github.com/kieler/elkjs)) — so it drops into TanStack Start, Next.js (App or Pages Router), Vite SPA, Remix, or any React 18/19 app.

### What's included

- **`SKILL.md`** — covers the libraries, client-only rendering (with TanStack Start *and* Next.js recipes), ELK positioning, CSS-variable theming, a build checklist, and a pitfalls table.
- **`reference/src/`** — a verbatim, framework-agnostic copy of the whole toolkit (~11 files) so a project with no prior setup can drop it in and go.
- **`reference/examples/`** — a complete example `DiagramSpec` to copy from.
- **README** catalog row for the new skill.

### Notes

- Theming uses generic `--app-*` host CSS-variable placeholders with safe light-mode fallbacks; dark mode works automatically if those tokens flip.
- Everything is written generically — no project-, package-, or stack-specific references.
