### PR TITLE
fix(skills): quote argument-hint values starting with '['

### DIFF
--- a/skills/architecture-diagrams/SKILL.md
+++ b/skills/architecture-diagrams/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: architecture-diagrams
 description: Build an interactive, layered architecture-diagram docs page (React Flow + ELK auto-layout), portable to TanStack Start, Next.js, or any React app
-argument-hint: [target app path]
+argument-hint: "[target app path]"
 ---
 
 # Architecture Diagrams

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: recall
 description: Load relevant prior context from layered session memory and archived transcripts
-argument-hint: [owner/repo] [keywords]
+argument-hint: "[owner/repo] [keywords]"
 disable-model-invocation: true
 ---
 


### PR DESCRIPTION
## Summary

Quote two `argument-hint` frontmatter values that start with `[`.

A YAML scalar beginning with `[` is parsed as a **flow sequence**, not a string:

- `skills/recall/SKILL.md` — `argument-hint: [owner/repo] [keywords]` is a one-element sequence followed by stray tokens, i.e. **invalid YAML**. The whole frontmatter block fails to parse, so `name`, `description`, and `disable-model-invocation` are lost with it.
- `skills/architecture-diagrams/SKILL.md` — the single-bracket `[target app path]` parses *without error* but as a **list** (`['target app path']`), not a string.

Quoting both makes the frontmatter valid and the hint a proper string. Verified with a YAML parser before/after. Skills whose hints start with `<` (most of them) are unaffected.
