### PR TITLE
docs(session-memory): push curation and keep MEMORY.md bounded

### DIFF
--- a/skills/session-memory/SKILL.md
+++ b/skills/session-memory/SKILL.md
@@ -33,6 +33,11 @@ files make recall easier across many sessions.
    the run; do not curate heavily there.
 4. Update `docs/agent-sessions/MEMORY.md` during `finalize` by promoting durable items from the
    session artifact. Keep entries short, deduplicated, and date-stamped.
+5. Keep `MEMORY.md` lean. It is the file recall reads first, so its size is a context cost paid by
+   every future session. Session artifacts are the immutable record; `MEMORY.md` is the
+   deduplicated projection of *current* truth — not an append-only pile. When promoting, **dedup and
+   supersede in place**: edit the existing entry for a decision/fact/pitfall (and bump its date)
+   rather than appending a conflicting duplicate. Give each durable entry a `(source: ...)` pointer.
 
 ## Prerequisites
 
@@ -236,6 +241,13 @@ Parse `$ARGUMENTS` — if it equals `finalize`, run this mode.
    ```markdown
    - YYYY-MM-DD: <fact/decision/pitfall> (source: YYYY-MM-DD-{session-name}-{scope})
    ```
+
+   **Curate, don't just append.** Before adding an entry, search `MEMORY.md` for an existing one on
+   the same topic; if present, update it (and its date) in place instead of stacking a duplicate,
+   and delete entries proven wrong. Because recall reads `MEMORY.md` first, keep it small — rough
+   budget a few hundred lines. When a section outgrows a screenful, move superseded or
+   stale-but-historical entries into `docs/agent-sessions/MEMORY-archive.md`, which is not on the
+   recall hot path and is consulted only when an agent needs deeper history.
 
    Also append a session-close breadcrumb to `docs/agent-sessions/memory/YYYY-MM-DD.md`:
 

--- a/skills/session-memory/SKILL.md
+++ b/skills/session-memory/SKILL.md
@@ -244,10 +244,11 @@ Parse `$ARGUMENTS` — if it equals `finalize`, run this mode.
 
    **Curate, don't just append.** Before adding an entry, search `MEMORY.md` for an existing one on
    the same topic; if present, update it (and its date) in place instead of stacking a duplicate,
-   and delete entries proven wrong. Because recall reads `MEMORY.md` first, keep it small — rough
-   budget a few hundred lines. When a section outgrows a screenful, move superseded or
-   stale-but-historical entries into `docs/agent-sessions/MEMORY-archive.md`, which is not on the
-   recall hot path and is consulted only when an agent needs deeper history.
+   and delete entries proven wrong. Because recall reads `MEMORY.md` first in full, keep it
+   skimmable — soft budget ~250 lines / ~5k tokens. When it outgrows that, move superseded or
+   stale-but-historical entries into `docs/agent-sessions/MEMORY-archive.md` (not on the recall hot
+   path), and if durable knowledge spans many topics, split it by topic so a recall loads only the
+   relevant slice.
 
    Also append a session-close breadcrumb to `docs/agent-sessions/memory/YYYY-MM-DD.md`:
 


### PR DESCRIPTION
## Summary

The `session-memory` skill promotes durable items into `MEMORY.md` but never bounded the file — and `MEMORY.md` is read first in full on every recall, so unbounded append growth is a context cost paid by **every** future session. This adds curation guidance.

## Change

A new [Memory Rule](https://github.com/photon-grove/skills/blob/8ad2928adffe20de1dae8b675ec1c1beb2129adf/skills/session-memory/SKILL.md#L36) and [finalize-step guidance](https://github.com/photon-grove/skills/blob/8ad2928adffe20de1dae8b675ec1c1beb2129adf/skills/session-memory/SKILL.md#L245): **dedup and supersede in place** rather than appending, delete entries proven wrong, hold a skimmable soft budget (~250 lines / ~5k tokens), and rotate stale entries into `MEMORY-archive.md` / shard by topic once the file grows. Docs-only and generic — no org/infra specifics (this repo is public).
