### PR TITLE
feat(pick-up-issue): defer PR body to woven pr-description guidance

### DIFF
--- a/skills/pick-up-issue/SKILL.md
+++ b/skills/pick-up-issue/SKILL.md
@@ -314,10 +314,13 @@ to the repo's `AGENTS.md`/`CONTRIBUTING.md` for any required sections or what to
 - Leave out routine CI hygiene (lint, typecheck, "ran the tests") — CI enforces it. Add a validation
   note only for change-specific checks CI doesn't cover.
 
-Write the body to a temp file and pass it with `--body-file` — don't inline shell-quoted Markdown:
+Write the body to a temp file and pass it with `--body-file` — don't inline shell-quoted Markdown.
+Use `mktemp` for a unique path so parallel agents (see the multi-agent note above) can't clobber
+each other's body:
 
 ```sh
-cat > /tmp/pr-body.md <<'EOF'
+body_file=$(mktemp -t pr-body.XXXXXX)
+cat > "$body_file" <<'EOF'
 ## Summary
 
 <why-first: the problem and impact, with inline links to specifics>
@@ -330,7 +333,8 @@ Closes #<number>
 
 🤖 Generated with Claude Code or Codex
 EOF
-gh pr create -R <owner>/<repo> --title "<concise title>" --body-file /tmp/pr-body.md
+gh pr create -R <owner>/<repo> --title "<concise title>" --body-file "$body_file"
+rm -f "$body_file"
 ```
 
 ### 9. Finalize session memory before shepherding

--- a/skills/pick-up-issue/SKILL.md
+++ b/skills/pick-up-issue/SKILL.md
@@ -299,28 +299,39 @@ git push -u origin HEAD
 
 ### 8. Open a pull request
 
-Create a PR that links to the issue:
+Write a concise, link-heavy body — a reviewer should grasp **why** and **what** in under a minute
+and reach the evidence in one click. Prefer a precise link over prose ("show, don't tell"); defer
+to the repo's `AGENTS.md`/`CONTRIBUTING.md` for any required sections or what to omit.
+
+- **`## Summary`** — 1–3 sentences, why-first: the problem/impact, with one clause of background to
+  orient a newcomer. Inline links carry the specifics.
+- **`## Change`** — what changed, linking the key call sites/functions. Link code at a pinned commit
+  SHA, not a branch name (branches rot on the next push): resolve with `git rev-parse HEAD`, find
+  lines with `grep -n` → `https://github.com/<owner>/<repo>/blob/<sha>/<path>#L<line>`. Note
+  scope/safety.
+- Add `Closes #<number>` so GitHub auto-closes the issue on merge. Link related PRs/issues with
+  **full URLs**, never bare `#123`.
+- Leave out routine CI hygiene (lint, typecheck, "ran the tests") — CI enforces it. Add a validation
+  note only for change-specific checks CI doesn't cover.
+
+Write the body to a temp file and pass it with `--body-file` — don't inline shell-quoted Markdown:
 
 ```sh
-gh pr create -R <owner>/<repo> --title "<concise title>" --body "$(cat <<'EOF'
+cat > /tmp/pr-body.md <<'EOF'
 ## Summary
 
-<1-3 bullet points describing the change>
+<why-first: the problem and impact, with inline links to specifics>
 
-## Issue
+## Change
+
+<what changed, linking the key call sites at a pinned SHA; note scope/safety>
 
 Closes #<number>
 
-## Test plan
-
-- [ ] <how to verify the change>
-
 🤖 Generated with Claude Code or Codex
 EOF
-)"
+gh pr create -R <owner>/<repo> --title "<concise title>" --body-file /tmp/pr-body.md
 ```
-
-Use `Closes #<number>` in the body so GitHub auto-closes the issue when the PR merges.
 
 ### 9. Finalize session memory before shepherding
 


### PR DESCRIPTION
## Summary

`pick-up-issue` step 8 carried its own inline `## Summary`/`## Issue`/`## Test plan` heredoc, so agents running the skill produced a templated body and never followed the concise, link-heavy PR-description guidance. This makes the skill generate bodies that match that guidance directly.

## Change

[Step 8](https://github.com/photon-grove/skills/blob/cbdbb771ca660e09c476ed32470d49c93593961a/skills/pick-up-issue/SKILL.md#L300) now describes a why-first `## Summary` + `## Change` (linking call sites at a pinned SHA), show-don't-tell with full URLs, and writes the body via `--body-file` instead of a shell-quoted heredoc — keeping `Closes #<number>`. Self-contained (no external link), since this repo is used across projects. Companion to [photon-grove/apps#2331](https://github.com/photon-grove/apps/pull/2331), which folds the same guidance into `AGENTS.md` + a runbook and retires the standalone `pr-description` skill.
