### PR TITLE
feat(skills): harden pick-up-issue and shepherd-to-merge against common friction

### DIFF
--- a/skills/pick-up-issue/SKILL.md
+++ b/skills/pick-up-issue/SKILL.md
@@ -262,6 +262,21 @@ discussions or references.
    conventions.
 3. Identify the files that need to change and the expected impact.
 4. Plan the implementation.
+5. **Confirm the root cause against ground truth before coding.** Plans and read-only query tools
+   are hypotheses, not proof. Before writing the first fix, reproduce or directly locate the root
+   cause in source code, build output, or live data. If you're about to change a config or wiring,
+   read the existing file first — don't propose additions without knowing what's already there. A
+   plan that names the wrong file or wrong line costs a full rework cycle; one read-then-verify step
+   prevents it.
+
+**Sub-agent path discipline:** When you spawn search or plan sub-agents, instruct them explicitly:
+
+> Return all file paths **relative to the worktree root** (not absolute). For example,
+> `src/auth/token.ts`, not `/home/user/.claude/worktrees/<name>/src/auth/token.ts`.
+
+Before the parent agent makes its first edit, rewrite any absolute path a sub-agent returns to the
+active worktree root. Never trust an absolute path from a sub-agent — multi-worktree setups have
+more than one checkout, and an edit to the wrong absolute path silently lands in the wrong tree.
 
 **While implementing:**
 
@@ -280,6 +295,16 @@ discussions or references.
 1. Run the project's test suite, linter, and type checker.
 2. Fix any failures before proceeding.
 
+**Lockfile and manifest hygiene:** After running package-manager commands (install, add, update) or
+build tasks that may touch generated files, inspect for incidental churn before staging:
+
+```sh
+git diff -- '**/package.json' '**/go.mod' '**/go.sum' pnpm-lock.yaml package-lock.json yarn.lock
+```
+
+Revert any churn that is not directly required by the change (e.g., unrelated version bumps,
+whitespace diffs in lock files). Stage only the diffs that belong to the fix.
+
 ### 7. Verify and push
 
 Before pushing, confirm you're on the correct branch and it tracks the right remote:
@@ -290,6 +315,26 @@ git branch -vv | grep '^\*'
 
 Verify the output shows your feature branch tracking `origin/<your-branch>`, not `main` or another
 branch. If something looks wrong, **stop and fix it** before pushing.
+
+**Pre-ready self-review — recurring P1 families.** Before marking the PR ready, scan the diff for
+these recurring failure modes:
+
+1. **Re-issuable commands produce a deterministic, stable ID.** Any derived ID (slug, filename,
+   resource name, cache key) must be the same if the command is re-run with the same inputs. An ID
+   that embeds `$(date)` or a random value will silently diverge on a retry, creating duplicate
+   artifacts or broken references. Verify that IDs derive only from stable inputs (issue number,
+   branch name, commit SHA).
+
+2. **Error classification over a shared channel uses a boundary sentinel.** When routing errors
+   from a shared queue or channel, each consumer must match only its own error class. A missing
+   boundary (e.g., a too-broad catch or a missing namespace prefix) lets one consumer swallow
+   another's errors, causing silent data loss. Verify that each handler has a clear, non-overlapping
+   selector and that unmatched messages fall through to a default or dead-letter path.
+
+3. **A filter or CLI must not exclude its own targets.** If the change adds or modifies a filter
+   (label filter, glob, `--exclude`, `--search`) or CLI argument parser, verify that the filter's
+   own invocation is not itself excluded. A filter that omits the very item it is searching for
+   returns empty results silently. Spot-check with a concrete example value.
 
 Then push:
 
@@ -342,6 +387,11 @@ rm -f "$body_file"
 Before shepherding, ensure the session memory is finalized and included in the PR's commit chain.
 Session memories committed after the PR is created (or on a different branch) can get stranded when
 the PR squash-merges.
+
+**Land session artifacts on the first push.** The session memory commit must reach the remote
+before CI runs its presence-gate check. If you commit session memory after the initial push, a
+CI presence-gate may already be failing — and you'll need an extra push round-trip to fix it.
+Commit and push session memory as part of the same push that opens the PR, not as a follow-up.
 
 If a session memory was started in step 5:
 

--- a/skills/shepherd-to-merge/SKILL.md
+++ b/skills/shepherd-to-merge/SKILL.md
@@ -99,6 +99,17 @@ After each PR reaches `MERGED`, print a one-line progress update:
 
 - `Completed <index>/<total>: #<number> <title> (<url>)`
 
+**Re-read the live PR number at each step.** Never rely on a PR number carried in context from a
+previous session or a previous step in this session — a PR can be closed and re-created, or the
+queue can shift. At the start of every step that targets a PR, read the authoritative number
+directly from the tool:
+
+```sh
+gh pr view --json number --jq .number
+```
+
+Use the number returned by the command, not the one cached in your reasoning context.
+
 ### 4. Check out the PR branch
 
 Ensure you're in the repo and check out the PR branch:
@@ -116,6 +127,15 @@ subagent should:
 - Review for correctness, security issues, performance concerns, and style consistency
 - Return a structured summary: a list of issues found (with file, line, and description) and an
   overall assessment (approve, request changes, or comment)
+
+**Sub-agent path discipline:** Instruct the review sub-agent explicitly:
+
+> Return all file paths **relative to the worktree root** (not absolute). For example,
+> `src/auth/token.ts`, not `/home/user/.claude/worktrees/<name>/src/auth/token.ts`.
+
+Before applying any fix the sub-agent identifies, rewrite any absolute path it returns to the
+active worktree root (`git rev-parse --show-toplevel`). An edit targeting the wrong absolute path
+silently lands in the wrong checkout in multi-worktree setups.
 
 Wait for the subagent to return its findings before proceeding.
 
@@ -141,6 +161,13 @@ you fix code **or**
 after you decide not to change behavior, post the reply **first**, then resolve (on repos that use
 resolved threads as a merge gate). Declining a suggestion is fine when explained — the reply is
 still required.
+
+**Confirm each reviewer concern against ground truth before coding.** A review comment is a
+hypothesis — the reviewer read the diff without full runtime context. Before writing any fix,
+locate the exact line or behavior in the live code or build output that confirms the concern is
+real. Read the existing implementation first; additive changes (new config, new wiring) often
+collide with code that already handles the case. One read-and-verify step before each fix
+prevents rework from coding against a misread root cause.
 
 For each piece of actionable feedback (from the subagent review, human reviewers, or the automatic
 review agent):


### PR DESCRIPTION
## Summary

Real agent sessions surfaced five recurring wasted-turn patterns — wrong-tree edits from
absolute sub-agent paths, fixes coded against unverified root causes, shepherd steps using
a stale PR number from context, the same P1 bug families caught on review repeatedly, and
incidental lockfile churn accidentally staged. This PR hardens the shared skills against
each of these patterns with generic, tool-agnostic guidance.

## Change

**`skills/pick-up-issue/SKILL.md`** ([step 6](https://github.com/photon-grove/skills/blob/66b37148fc3347eaec97ef411364455494a13308/skills/pick-up-issue/SKILL.md)):
- Step 6: adds **sub-agent path discipline** — instruct sub-agents to return worktree-relative
  paths; parent rewrites any absolute path to the active worktree root before the first edit.
- Step 6: adds **confirm the root cause before coding** — plans and read-only query tools are
  hypotheses; reproduce or locate the bug in source/build/live data, and read existing config
  before proposing additions.
- Step 6 (after implementing): adds **lockfile/manifest hygiene** — inspect and revert incidental
  churn from package-manager/build tasks before staging.
- Step 7: adds **pre-ready self-review checklist** for three recurring P1 families: re-issuable
  commands must produce a stable, deterministic ID; error classification over a shared channel
  needs a non-overlapping boundary sentinel; a filter/CLI must not exclude its own targets.
- Step 9: adds **land session artifacts early** reminder — commit and push session memory on the
  same push that opens the PR so CI presence-gates never cost an extra round-trip.

**`skills/shepherd-to-merge/SKILL.md`** ([step 3, 5, 6](https://github.com/photon-grove/skills/blob/66b37148fc3347eaec97ef411364455494a13308/skills/shepherd-to-merge/SKILL.md)):
- Step 3: adds **re-read the live PR number at each step** via `gh pr view --json number` rather
  than carrying a number in context.
- Step 5: adds **sub-agent path discipline** (same as pick-up-issue) for the review sub-agent.
- Step 6: adds **confirm each reviewer concern against ground truth before coding** — reviewer
  comments are hypotheses; locate the line in live code before writing a fix.

All wording is tool- and org-agnostic (no private repo names, no private infra, no internal paths).

Closes #52

🤖 Generated with Claude Code
